### PR TITLE
Use the Celeste difficulty rating system

### DIFF
--- a/levels/demo_platformer/info.json
+++ b/levels/demo_platformer/info.json
@@ -2,6 +2,6 @@
     "id": "demo_platformer",
     "fullName": "Demo Platformer",
     "creators": "UTheCat",
-    "difficulty": 5.03,
+    "difficulty": 10,
     "scenePath": "level.tscn"
 }

--- a/levels/shape_variety/info.json
+++ b/levels/shape_variety/info.json
@@ -2,6 +2,6 @@
     "id": "shape_variety",
     "fullName": "Shape Variety Demo",
     "creators": "UTheCat",
-    "difficulty": 6.54,
+    "difficulty": 19,
     "scenePath": "level.tscn"
 }

--- a/src/core/Levels/Difficulty.cs
+++ b/src/core/Levels/Difficulty.cs
@@ -17,7 +17,7 @@ namespace Jumpvalley.Levels
         /// <br/><br/>
         /// For example, a level with a difficulty rating of 23.5
         /// would be yellow-intermediate if you were using
-        /// the Celeste difficulty rating system
+        /// the <see href="https://www.celestegame.com/">Celeste</see> difficulty rating system
         /// (specifically, the system found in the Difficulty Reference Chart in
         /// <see href="https://docs.google.com/spreadsheets/d/1KNJ344lsZEmTU9P6eeFInckUbT5dkaWhRcxv_Yy2ZS0">Parrot's Celeste Clears List</see>).
         /// </summary>

--- a/src/core/Levels/Difficulty.cs
+++ b/src/core/Levels/Difficulty.cs
@@ -1,9 +1,4 @@
 ﻿using Godot;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Jumpvalley.Levels
 {
@@ -19,7 +14,12 @@ namespace Jumpvalley.Levels
 
         /// <summary>
         /// The difficulty's numerical measurement.
-        /// For example, a level that's low-end hard can have a rating of 3.25.
+        /// <br/><br/>
+        /// For example, a level with a difficulty rating of 23.5
+        /// would be yellow-intermediate if you were using
+        /// the Celeste difficulty rating system
+        /// (specifically, the system found in the Difficulty Reference Chart in
+        /// <see href="https://docs.google.com/spreadsheets/d/1KNJ344lsZEmTU9P6eeFInckUbT5dkaWhRcxv_Yy2ZS0">Parrot's Celeste Clears List</see>).
         /// </summary>
         public double Rating;
 

--- a/src/core/Levels/DifficultyPresets.cs
+++ b/src/core/Levels/DifficultyPresets.cs
@@ -24,13 +24,13 @@ namespace Jumpvalley.Levels
             new List<Difficulty>()
             {
                 new Difficulty("Beginner", 0.0, new Color(231f / 255f, 0.41f, 1f)),
-                new Difficulty("Intermediate", 15.0, new Color(231f / 255f, 0.41f, 1f)),
-                new Difficulty("Advanced", 30.0, new Color(231f / 255f, 0.41f, 1f)),
-                new Difficulty("Expert", 45.0, new Color(231f / 255f, 0.41f, 1f)),
-                new Difficulty("Grandmaster", 60.0, new Color(231f / 255f, 0.41f, 1f)),
-                new Difficulty("GM+1", 80.0, new Color(231f / 255f, 0.41f, 1f)),
-                new Difficulty("GM+2", 90.0, new Color(231f / 255f, 0.41f, 1f)),
-                new Difficulty("GM+3", 95.0, new Color(231f / 255f, 0.41f, 1f)),
+                new Difficulty("Intermediate", 15.0, new Color(198f / 255f, 0.44f, 1f)),
+                new Difficulty("Advanced", 30.0, new Color(140f / 255f, 0.47f, 0.88f)),
+                new Difficulty("Expert", 45.0, new Color(95f / 255f, 0.53f, 1f)),
+                new Difficulty("Grandmaster", 60.0, new Color(51f / 255f, 0.47f, 1f)),
+                new Difficulty("GM+1", 80.0, new Color(36f / 255f, 0.55f, 1f)),
+                new Difficulty("GM+2", 90.0, new Color(8f / 255f, 0.6f, 1f)),
+                new Difficulty("GM+3", 95.0, new Color(332f / 255f, 0.92f, 1f)),
             }
         );
     }

--- a/src/core/Levels/DifficultyPresets.cs
+++ b/src/core/Levels/DifficultyPresets.cs
@@ -14,29 +14,11 @@ namespace Jumpvalley.Levels
         public readonly static Difficulty FALLBACK = new Difficulty();
 
         /// <summary>
-        /// Jumpvalley's main set of difficulties. These are taken directly from Juke's Towers of Hell.
-        /// <br/>
-        /// Note that Jumpvalley may use a different set of difficulty ratings in the future.
+        /// Jumpvalley's main set of difficulties.
         /// </summary>
         public readonly static List<Difficulty> PRIMARY = new List<Difficulty>
         {
-            // Remember that when setting this, make sure that each difficulty's list index matches with the difficulty's numerical rating rounded down
-            new Difficulty("Effortless", 0, Color.Color8(0, 206, 0)),
-            new Difficulty("Easy", 1, Color.Color8(117, 243, 71)),
-            new Difficulty("Medium", 2, Color.Color8(0, 206, 0)),
-            new Difficulty("Hard", 3, Color.Color8(253, 124, 0)),
-            new Difficulty("Difficult", 4, Color.Color8(255, 12, 4)),
-            new Difficulty("Challenging", 5, Color.Color8(193, 0, 0)),
-            new Difficulty("Intense", 6, Color.Color8(25, 40, 50)),
-            new Difficulty("Remorseless", 7, Color.Color8(200, 0, 200)),
-            new Difficulty("Insane", 8, Color.Color8(0, 0, 255)),
-            new Difficulty("Extreme", 9, Color.Color8(3, 137, 255)),
-            new Difficulty("Terrifying", 10, Color.Color8(0, 255, 255)),
-            new Difficulty("Catastrophic", 11, Color.Color8(255, 255, 255)),
-
-            // difficulties beyond sane limits
-            new Difficulty("Horrific", 12, Color.Color8(140, 139, 238)),
-            new Difficulty("Unreal", 13, Color.Color8(81, 0, 203))
+            
         };
 
         /// <returns>

--- a/src/core/Levels/DifficultyPresets.cs
+++ b/src/core/Levels/DifficultyPresets.cs
@@ -23,7 +23,14 @@ namespace Jumpvalley.Levels
         public readonly static DifficultySet PRIMARY_DIFFICULTIES = new DifficultySet(
             new List<Difficulty>()
             {
-                new Difficulty("Beginner", 0.0, new Color(231f / 255f, 0.41f, 1f))
+                new Difficulty("Beginner", 0.0, new Color(231f / 255f, 0.41f, 1f)),
+                new Difficulty("Intermediate", 15.0, new Color(231f / 255f, 0.41f, 1f)),
+                new Difficulty("Advanced", 30.0, new Color(231f / 255f, 0.41f, 1f)),
+                new Difficulty("Expert", 45.0, new Color(231f / 255f, 0.41f, 1f)),
+                new Difficulty("Grandmaster", 60.0, new Color(231f / 255f, 0.41f, 1f)),
+                new Difficulty("GM+1", 80.0, new Color(231f / 255f, 0.41f, 1f)),
+                new Difficulty("GM+2", 90.0, new Color(231f / 255f, 0.41f, 1f)),
+                new Difficulty("GM+3", 95.0, new Color(231f / 255f, 0.41f, 1f)),
             }
         );
     }

--- a/src/core/Levels/DifficultyPresets.cs
+++ b/src/core/Levels/DifficultyPresets.cs
@@ -15,6 +15,10 @@ namespace Jumpvalley.Levels
 
         /// <summary>
         /// Jumpvalley's main set of difficulties.
+        /// <br/><br/>
+        /// These come from the Celeste community.
+        /// The numerical difficulty ratings assigned to each difficulty name
+        /// come from <see href="https://docs.google.com/spreadsheets/d/1KNJ344lsZEmTU9P6eeFInckUbT5dkaWhRcxv_Yy2ZS0">Parrot's Celeste Clears List</see>.
         /// </summary>
         public readonly static List<Difficulty> PRIMARY = new List<Difficulty>
         {

--- a/src/core/Levels/DifficultyPresets.cs
+++ b/src/core/Levels/DifficultyPresets.cs
@@ -20,19 +20,11 @@ namespace Jumpvalley.Levels
         /// The numerical difficulty ratings assigned to each difficulty name
         /// come from <see href="https://docs.google.com/spreadsheets/d/1KNJ344lsZEmTU9P6eeFInckUbT5dkaWhRcxv_Yy2ZS0">Parrot's Celeste Clears List</see>.
         /// </summary>
-        public readonly static List<Difficulty> PRIMARY = new List<Difficulty>
-        {
-            
-        };
-
-        /// <returns>
-        /// The difficulty in the <see cref="PRIMARY"/> list associated with the given numerical rating specified in the <paramref name="rating"/> parameter.
-        /// </returns>
-        public static Difficulty GetPrimaryDifficultyFromRating(double rating)
-        {
-            return PRIMARY[
-                Mathf.FloorToInt(Mathf.Clamp(rating, 0, PRIMARY.Count))
-                ];
-        }
+        public readonly static DifficultySet PRIMARY_DIFFICULTIES = new DifficultySet(
+            new List<Difficulty>()
+            {
+                new Difficulty("Beginner", 0.0, new Color(231f / 255f, 0.41f, 1f))
+            }
+        );
     }
 }

--- a/src/core/Levels/DifficultyPresets.cs
+++ b/src/core/Levels/DifficultyPresets.cs
@@ -16,7 +16,7 @@ namespace Jumpvalley.Levels
         /// <summary>
         /// Jumpvalley's main set of difficulties.
         /// <br/><br/>
-        /// These come from the Celeste community.
+        /// These come from the <see href="https://www.celestegame.com/">Celeste</see> community.
         /// The numerical difficulty ratings assigned to each difficulty name
         /// come from <see href="https://docs.google.com/spreadsheets/d/1KNJ344lsZEmTU9P6eeFInckUbT5dkaWhRcxv_Yy2ZS0">Parrot's Celeste Clears List</see>.
         /// </summary>

--- a/src/core/Levels/DifficultyPresets.cs
+++ b/src/core/Levels/DifficultyPresets.cs
@@ -17,8 +17,8 @@ namespace Jumpvalley.Levels
         /// Jumpvalley's main set of difficulties.
         /// <br/><br/>
         /// These come from the <see href="https://www.celestegame.com/">Celeste</see> community.
-        /// The numerical difficulty ratings assigned to each difficulty name
-        /// come from <see href="https://docs.google.com/spreadsheets/d/1KNJ344lsZEmTU9P6eeFInckUbT5dkaWhRcxv_Yy2ZS0">Parrot's Celeste Clears List</see>.
+        /// The numerical difficulty ratings assigned to each difficulty name come from
+        /// the Difficulty Reference Chart in <see href="https://docs.google.com/spreadsheets/d/1KNJ344lsZEmTU9P6eeFInckUbT5dkaWhRcxv_Yy2ZS0">Parrot's Celeste Clears List</see>.
         /// </summary>
         public readonly static DifficultySet PRIMARY_DIFFICULTIES = new DifficultySet(
             new List<Difficulty>()

--- a/src/core/Levels/DifficultySet.cs
+++ b/src/core/Levels/DifficultySet.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace Jumpvalley.Levels
+{
+    /// <summary>
+    /// Class that groups multiple difficulties together.
+    /// Useful when you want to have all the difficulties within a game
+    /// in one place and be able to perform some calculations based off of them.
+    /// </summary>
+    public partial class DifficultySet
+    {
+        /// <summary>
+        /// The list of difficulties within the set
+        /// </summary>
+        public List<Difficulty> Difficulties;
+
+        /// <summary>
+        /// Returns the difficulty within the <see cref="Difficulties"/> list
+        /// who has the highest difficulty rating less than or equal to the
+        /// difficulty rating specified in the <paramref name="rating"/> parameter.
+        /// </summary>
+        /// <param name="rating">The difficulty rating</param>
+        /// <returns>The corresponding difficulty</returns>
+        public Difficulty GetDifficultyByRating(double rating)
+        {
+            return null;
+        }
+    }
+}

--- a/src/core/Levels/DifficultySet.cs
+++ b/src/core/Levels/DifficultySet.cs
@@ -23,7 +23,23 @@ namespace Jumpvalley.Levels
         /// <returns>The corresponding difficulty</returns>
         public Difficulty GetDifficultyByRating(double rating)
         {
-            return null;
+            Difficulty difficulty = null;
+            double correspondingRating = 0;
+            bool firstRatingReached = false;
+
+            foreach (Difficulty d in Difficulties)
+            {
+                double diffRating = d.Rating;
+
+                if ((firstRatingReached == false || diffRating > correspondingRating) && diffRating <= rating)
+                {
+                    firstRatingReached = true;
+                    correspondingRating = diffRating;
+                    difficulty = d;
+                }
+            }
+
+            return difficulty;
         }
     }
 }

--- a/src/core/Levels/DifficultySet.cs
+++ b/src/core/Levels/DifficultySet.cs
@@ -15,6 +15,20 @@ namespace Jumpvalley.Levels
         public List<Difficulty> Difficulties;
 
         /// <summary>
+        /// Creates a new instance of <see cref="DifficultySet"/> with an initial list of difficulties. 
+        /// </summary>
+        /// <param name="difficulties">The initial list of difficulties</param>
+        public DifficultySet(List<Difficulty> difficulties)
+        {
+            Difficulties = difficulties;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="DifficultySet"/> with a blank list of difficulties.
+        /// </summary>
+        public DifficultySet() : this(new List<Difficulty>()) { }
+
+        /// <summary>
         /// Returns the difficulty within the <see cref="Difficulties"/> list
         /// who has the highest difficulty rating less than or equal to the
         /// difficulty rating specified in the <paramref name="rating"/> parameter.

--- a/src/core/Levels/LevelInfo.cs
+++ b/src/core/Levels/LevelInfo.cs
@@ -59,7 +59,7 @@ namespace Jumpvalley.Levels
                 double difficultyRating = difficultyNode.GetValue<double>();
 
                 // We'll need to retain the exact numerical difficulty when setting LevelDifficulty
-                Difficulty difficulty = DifficultyPresets.GetPrimaryDifficultyFromRating(difficultyRating);
+                Difficulty difficulty = DifficultyPresets.PRIMARY_DIFFICULTIES.GetDifficultyByRating(difficultyRating);
                 LevelDifficulty = new Difficulty(difficulty.Name, difficultyRating, difficulty.Color);
             }
         }

--- a/src/core/Levels/LevelInfoFile.cs
+++ b/src/core/Levels/LevelInfoFile.cs
@@ -62,7 +62,7 @@ namespace Jumpvalley.Levels
             }
 
             // We'll need to retain the exact numerical difficulty when setting LevelDifficulty
-            Difficulty difficulty = DifficultyPresets.GetPrimaryDifficultyFromRating(difficultyRating);
+            Difficulty difficulty = DifficultyPresets.PRIMARY_DIFFICULTIES.GetDifficultyByRating(difficultyRating);
             LevelDifficulty = new Difficulty(difficulty.Name, difficultyRating, difficulty.Color);
         }
     }


### PR DESCRIPTION
Jumpvalley will eventually have a checkpoint system for levels.

Luckily, the [Celeste](https://www.celestegame.com) community has made a nice difficulty rating system for rating the difficulties of precision platformer levels with checkpoints in them. This difficulty rating system would therefore fit nicely in Jumpvalley.

As of this PR, Jumpvalley now uses the Celeste difficulty rating system.

The changes in this PR break backwards-compatibility with previous versions of Jumpvalley. However, they're needed in order to have better support for levels with checkpoints.