### PR TITLE
Add feature tag for custom user directory

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -17,6 +17,8 @@ config/features=PackedStringArray("4.2", "C#")
 run/max_fps=60
 boot_splash/show_image=false
 config/icon="res://icons/music_note_icon_256dp.png"
+config/use_custom_user_dir.jumpvalley_custom_user_dir=true
+config/custom_user_dir_name.jumpvalley_custom_user_dir="Jumpvalley"
 
 [display]
 


### PR DESCRIPTION
This PR adds a Godot feature tag that can be used to specify that Jumpvalley should use a custom user directory (that's different from the default user directory for Godot projects).

This custom user directory is primarily intended for release builds of Jumpvalley. When running a debug build of Jumpvalley directly from the Godot editor, the user data directory should still be Godot's default user data directory for projects.