### PR TITLE
Change the node structure of Interactives

### DIFF
--- a/levels/demo_platformer/level.tscn
+++ b/levels/demo_platformer/level.tscn
@@ -186,7 +186,9 @@ mesh = SubResource("BoxMesh_eq5ge")
 
 [node name="Spinner" type="StaticBody3D" parent="Interactives/Floor2"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 58, 22)
-metadata/interactive_type = "Spinner"
+
+[node name="_Interactive" type="Node" parent="Interactives/Floor2/Spinner"]
+metadata/type = "Spinner"
 metadata/constant_angular_velocity = Vector3(0, 0, 0)
 metadata/constant_angular_velocity_degrees = Vector3(0, 30, 0)
 

--- a/levels/demo_platformer/level.tscn
+++ b/levels/demo_platformer/level.tscn
@@ -42,7 +42,9 @@ size = Vector3(50, 100, 50)
 [node name="Interactives" type="Node3D" parent="."]
 
 [node name="InteractiveRootNode" type="Node3D" parent="Interactives"]
-metadata/interactive_type = "TestInteractive"
+
+[node name="_Interactive" type="Node" parent="Interactives/InteractiveRootNode"]
+metadata/type = "TestInteractive"
 metadata/property1 = false
 metadata/property2 = 0.5
 

--- a/levels/demo_platformer/level.tscn
+++ b/levels/demo_platformer/level.tscn
@@ -169,7 +169,9 @@ mesh = SubResource("BoxMesh_hf4fk")
 
 [node name="Spinner" type="StaticBody3D" parent="Interactives/Floor1"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 1, 6)
-metadata/interactive_type = "Spinner"
+
+[node name="_Interactive" type="Node" parent="Interactives/Floor1/Spinner"]
+metadata/type = "Spinner"
 metadata/constant_angular_velocity = Vector3(0, 0, 0)
 metadata/constant_angular_velocity_degrees = Vector3(0, 15, 0)
 

--- a/levels/shape_variety/level.tscn
+++ b/levels/shape_variety/level.tscn
@@ -111,16 +111,18 @@ shape = SubResource("BoxShape3D_b766v")
 material_override = ExtResource("2_tx8br")
 mesh = SubResource("BoxMesh_63nxk")
 
-[node name="Box8" type="StaticBody3D" parent="Interactives"]
+[node name="Spinner" type="StaticBody3D" parent="Interactives"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5, 14.5, 26.5)
-metadata/interactive_type = "Spinner"
+
+[node name="_Interactive" type="Node" parent="Interactives/Spinner"]
+metadata/type = "Spinner"
 metadata/constant_angular_velocity = Vector3(0, 0, 0)
 metadata/constant_angular_velocity_degrees = Vector3(0, 30, 0)
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/Box8"]
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/Spinner"]
 shape = SubResource("BoxShape3D_fw6gq")
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="Interactives/Box8"]
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Interactives/Spinner"]
 material_override = ExtResource("2_tx8br")
 mesh = SubResource("BoxMesh_p3poc")
 

--- a/main.tscn
+++ b/main.tscn
@@ -91,6 +91,6 @@ metadata/initialization_level = "res://levels/shape_variety/"
 [node name="PrimaryMusic" type="Node" parent="Music"]
 
 [node name="Music" type="Node" parent="Music/PrimaryMusic"]
-metadata/song1 = "res://addons/music/1215548_Shivers"
+metadata/song1 = "res://addons/music/1215548_Shivers/"
 
 [node name="MusicZones" type="Node3D" parent="Music"]

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -139,7 +139,9 @@ skeleton = NodePath("../..")
 
 [node name="Spinner" type="StaticBody3D" parent="Interactives"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15, 1, -22.5)
-metadata/interactive_type = "Spinner"
+
+[node name="_Interactive" type="Node" parent="Interactives/Spinner"]
+metadata/type = "Spinner"
 metadata/constant_angular_velocity = Vector3(0, 0, 0)
 metadata/constant_angular_velocity_degrees = Vector3(0, 45, 0)
 
@@ -154,7 +156,9 @@ mesh = SubResource("BoxMesh_4aon4")
 
 [node name="Spinner2" type="StaticBody3D" parent="Interactives/RaisedPlatformThing"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -20, 1, -38)
-metadata/interactive_type = "Spinner"
+
+[node name="_Interactive" type="Node" parent="Interactives/RaisedPlatformThing/Spinner2"]
+metadata/type = "Spinner"
 metadata/constant_angular_velocity = Vector3(0, 0, 0)
 metadata/constant_angular_velocity_degrees = Vector3(0, 0, 15)
 

--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -8,8 +8,9 @@ namespace Jumpvalley.Levels.Interactives
     /// <summary>
     /// A subclass of <see cref="Interactive"/> that operates over a Godot node.
     /// It makes using a Godot node's properties and metadata easier.
+    /// See the relevant <see href="https://github.com/UTheCat/jumpvalley/wiki/Interactives#node-based-interactives">wiki section</see> for details.
     /// </summary>
-    public partial class InteractiveNode: Interactive
+    public partial class InteractiveNode : Interactive
     {
         /// <summary>
         /// What an interactive's node marker name should begin with

--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -12,7 +12,8 @@ namespace Jumpvalley.Levels.Interactives
     public partial class InteractiveNode: Interactive
     {
         /// <summary>
-        /// The Godot node being operated on
+        /// The node which indicates that its parent node belongs to an interactive.
+        /// Its name should begin with <c>_Interactive</c>
         /// </summary>
         public Node ActualNode { get; private set; }
 

--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -50,7 +50,7 @@ namespace Jumpvalley.Levels.Interactives
         /// <c>true</c> if the metadata entry under the given name was found
         /// and grabbing its value was successful, <c>false</c> otherwise.
         /// </returns>
-        public bool TryGetMeta(string name, out Variant meta)
+        public bool TryGetMarkerMeta(string name, out Variant meta)
         {
             Node marker = NodeMarker;
             if (marker != null)
@@ -77,10 +77,10 @@ namespace Jumpvalley.Levels.Interactives
         /// <c>true</c> if the metadata entry under the given name was found
         /// and grabbing its value was successful, <c>false</c> otherwise.
         /// </returns>
-        public bool TryGetMeta<[MustBeVariant] T>(string name, out T meta)
+        public bool TryGetMarkerMeta<[MustBeVariant] T>(string name, out T meta)
         {
             Variant metadataValue;
-            bool success = TryGetMeta(name, out metadataValue);
+            bool success = TryGetMarkerMeta(name, out metadataValue);
 
             if (success)
             {
@@ -98,7 +98,7 @@ namespace Jumpvalley.Levels.Interactives
         /// </summary>
         /// <param name="name">The name of the metadata entry</param>
         /// <param name="value">The value to set the metadata entry to</param>
-        public void SetMeta(string name, Variant value)
+        public void SetMarkerMeta(string name, Variant value)
         {
             NodeMarker.SetMeta(name, value);
         }

--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -24,6 +24,11 @@ namespace Jumpvalley.Levels.Interactives
         public Node NodeMarker { get; private set; }
 
         /// <summary>
+        /// The interactive's root node
+        /// </summary>
+        public Node RootNode => NodeMarker.GetParent();
+
+        /// <summary>
         /// Creates a new instance of <see cref="InteractiveNode"/> for a given <see cref="Stopwatch"/> and <see cref="Node"/>
         /// </summary>
         /// <param name="stopwatch">The stopwatch to bind the interactive to</param>

--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -93,6 +93,17 @@ namespace Jumpvalley.Levels.Interactives
         }
 
         /// <summary>
+        /// Sets the metadata entry belonging to <see cref="NodeMarker"/>
+        /// with the given name to the specified value.
+        /// </summary>
+        /// <param name="name">The name of the metadata entry</param>
+        /// <param name="value">The value to set the metadata entry to</param>
+        public void SetMeta(string name, Variant value)
+        {
+            NodeMarker.SetMeta(name, value);
+        }
+
+        /// <summary>
         /// Event that's raised when one of the metadata of the node changes.
         /// </summary>
         //public event EventHandler<NodeMetadataChangedArgs> NodeMetadataChanged;

--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -12,6 +12,11 @@ namespace Jumpvalley.Levels.Interactives
     public partial class InteractiveNode: Interactive
     {
         /// <summary>
+        /// What an interactive's node marker name should begin with
+        /// </summary>
+        public static readonly string NODE_MARKER_NAME_PREFIX = "_Interactive";
+
+        /// <summary>
         /// The node which indicates that its parent node is the root node of an interactive.
         /// Its name should begin with <c>_Interactive</c>
         /// </summary>

--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -12,21 +12,21 @@ namespace Jumpvalley.Levels.Interactives
     public partial class InteractiveNode: Interactive
     {
         /// <summary>
-        /// The node which indicates that its parent node belongs to an interactive.
+        /// The node which indicates that its parent node is the root node of an interactive.
         /// Its name should begin with <c>_Interactive</c>
         /// </summary>
-        public Node ActualNode { get; private set; }
+        public Node NodeMarker { get; private set; }
 
         /// <summary>
         /// Creates a new instance of <see cref="InteractiveNode"/> for a given <see cref="Stopwatch"/> and <see cref="Node"/>
         /// </summary>
         /// <param name="stopwatch">The stopwatch to bind the interactive to</param>
         /// <param name="node">The node to operate over</param>
-        public InteractiveNode(OffsetStopwatch stopwatch, Node node) : base(stopwatch)
+        public InteractiveNode(OffsetStopwatch stopwatch, Node nodeMarker) : base(stopwatch)
         {
-            if (node == null) throw new ArgumentNullException("node");
+            if (nodeMarker == null) throw new ArgumentNullException(nameof(nodeMarker));
 
-            ActualNode = node;
+            NodeMarker = nodeMarker;
         }
 
         /// <summary>

--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -67,6 +67,32 @@ namespace Jumpvalley.Levels.Interactives
         }
 
         /// <summary>
+        /// Version of <see cref="TryGetMeta(string, out Variant)"/>
+        /// that outputs the metadata entry value as a specified type
+        /// <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="name">The name of the metadata entry</param>
+        /// <param name="meta">The reference variable where the metadata entry value should be stored</param>
+        /// <returns>
+        /// <c>true</c> if the metadata entry under the given name was found
+        /// and grabbing its value was successful, <c>false</c> otherwise.
+        /// </returns>
+        public bool TryGetMeta<[MustBeVariant] T>(string name, out T meta)
+        {
+            Variant metadataValue;
+            bool success = TryGetMeta(name, out metadataValue);
+
+            if (success)
+            {
+                meta = metadataValue.As<T>();
+                return true;
+            }
+
+            meta = default;
+            return false;
+        }
+
+        /// <summary>
         /// Event that's raised when one of the metadata of the node changes.
         /// </summary>
         //public event EventHandler<NodeMetadataChangedArgs> NodeMetadataChanged;

--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -41,6 +41,32 @@ namespace Jumpvalley.Levels.Interactives
         }
 
         /// <summary>
+        /// Attempts to get the value of a metadata entry with a specified name
+        /// if it exists and assigns it to the <paramref name="meta"/> reference variable.
+        /// </summary>
+        /// <param name="name">The name of the metadata entry</param>
+        /// <param name="meta">The reference variable where the metadata entry value should be stored</param>
+        /// <returns>
+        /// <c>true</c> if the metadata entry under the given name was found
+        /// and grabbing its value was successful, <c>false</c> otherwise.
+        /// </returns>
+        public bool TryGetMeta(string name, out Variant meta)
+        {
+            Node marker = NodeMarker;
+            if (marker != null)
+            {
+                if (marker.HasMeta(name))
+                {
+                    meta = marker.GetMeta(name);
+                    return true;
+                }
+            }
+
+            meta = default;
+            return false;
+        }
+
+        /// <summary>
         /// Event that's raised when one of the metadata of the node changes.
         /// </summary>
         //public event EventHandler<NodeMetadataChangedArgs> NodeMetadataChanged;

--- a/src/core/Levels/Interactives/InteractiveToolkit.cs
+++ b/src/core/Levels/Interactives/InteractiveToolkit.cs
@@ -15,7 +15,7 @@ namespace Jumpvalley.Levels.Interactives
         /// <summary>
         /// Name of the metadata entry that indicates the class that will be running the interactive.
         /// </summary>
-        public static readonly string INTERACTIVE_TYPE_METADATA_NAME = "interactive_type";
+        public static readonly string INTERACTIVE_TYPE_METADATA_NAME = "type";
 
         /// <summary>
         /// Returns the current number of physics updates per second

--- a/src/core/Levels/Interactives/InteractiveToolkit.cs
+++ b/src/core/Levels/Interactives/InteractiveToolkit.cs
@@ -23,7 +23,7 @@ namespace Jumpvalley.Levels.Interactives
         /// <returns>The current number of physics updates per second</returns>
         public static int GetPhysicsTicksPerSecond()
         {
-            return Engine.MaxFps;
+            return Engine.PhysicsTicksPerSecond;
         }
     }
 }

--- a/src/core/Levels/Interactives/Mechanics/Spinner.cs
+++ b/src/core/Levels/Interactives/Mechanics/Spinner.cs
@@ -90,9 +90,10 @@ namespace Jumpvalley.Levels.Interactives.Mechanics
                 SetMarkerMeta(CONSTANT_ANGULAR_VELOCITY_METADATA_NAME, angularVelocityRad);
             }
 
-            if (body.HasMeta(CONSTANT_ANGULAR_VELOCITY_METADATA_NAME))
+            Vector3 angularVelocity;
+            if (TryGetMarkerMeta<Vector3>(CONSTANT_ANGULAR_VELOCITY_METADATA_NAME, out angularVelocity))
             {
-                ConstantAngularVelocity = body.GetMeta(CONSTANT_ANGULAR_VELOCITY_METADATA_NAME).As<Vector3>();
+                ConstantAngularVelocity = angularVelocity;
             }
             else
             {

--- a/src/core/Levels/Interactives/Mechanics/Spinner.cs
+++ b/src/core/Levels/Interactives/Mechanics/Spinner.cs
@@ -77,17 +77,17 @@ namespace Jumpvalley.Levels.Interactives.Mechanics
             //body.ConstantAngularVelocity = Vector3.Zero;
             //originalConstantAngularVelocity = body.ConstantAngularVelocity;
 
-            Vector3 angularVelocityDegrees;
+            Vector3 angularVelocityDeg;
             if (TryGetMarkerMeta<Vector3>(
                 CONSTANT_ANGULAR_VELOCITY_DEGREES_METADATA_NAME,
-                out angularVelocityDegrees))
+                out angularVelocityDeg))
             {
-                Vector3 angularVelocity = Vector3.Zero;
-                angularVelocity.X = Mathf.DegToRad(angularVelocityDegrees.X);
-                angularVelocity.Y = Mathf.DegToRad(angularVelocityDegrees.Y);
-                angularVelocity.Z = Mathf.DegToRad(angularVelocityDegrees.Z);
+                Vector3 angularVelocityRad = Vector3.Zero;
+                angularVelocityRad.X = Mathf.DegToRad(angularVelocityDeg.X);
+                angularVelocityRad.Y = Mathf.DegToRad(angularVelocityDeg.Y);
+                angularVelocityRad.Z = Mathf.DegToRad(angularVelocityDeg.Z);
 
-                SetMarkerMeta(CONSTANT_ANGULAR_VELOCITY_METADATA_NAME, angularVelocity);
+                SetMarkerMeta(CONSTANT_ANGULAR_VELOCITY_METADATA_NAME, angularVelocityRad);
             }
 
             if (body.HasMeta(CONSTANT_ANGULAR_VELOCITY_METADATA_NAME))

--- a/src/core/Levels/Interactives/Mechanics/Spinner.cs
+++ b/src/core/Levels/Interactives/Mechanics/Spinner.cs
@@ -56,13 +56,13 @@ namespace Jumpvalley.Levels.Interactives.Mechanics
             set
             {
                 _constantAngularVelocity = value;
-                body.SetMeta(CONSTANT_ANGULAR_VELOCITY_METADATA_NAME, value);
+                SetMarkerMeta(CONSTANT_ANGULAR_VELOCITY_METADATA_NAME, value);
             }
         }
 
         public Spinner(OffsetStopwatch stopwatch, Node node) : base(stopwatch, node)
         {
-            body = node as StaticBody3D;
+            body = RootNode as StaticBody3D;
             if (body == null) throw new ArgumentException("The node specified in the 2nd argument must be a StaticBody3D.");
 
             // Set the initial constant angular velocity of the StaticBody3D to Vector3.Zero.
@@ -77,14 +77,17 @@ namespace Jumpvalley.Levels.Interactives.Mechanics
             //body.ConstantAngularVelocity = Vector3.Zero;
             //originalConstantAngularVelocity = body.ConstantAngularVelocity;
 
-            if (body.HasMeta(CONSTANT_ANGULAR_VELOCITY_DEGREES_METADATA_NAME))
+            Vector3 angularVelocityDegrees;
+            if (TryGetMarkerMeta<Vector3>(
+                CONSTANT_ANGULAR_VELOCITY_DEGREES_METADATA_NAME,
+                out angularVelocityDegrees))
             {
-                Vector3 angularVelocity = body.GetMeta(CONSTANT_ANGULAR_VELOCITY_DEGREES_METADATA_NAME).As<Vector3>();
-                angularVelocity.X = Mathf.DegToRad(angularVelocity.X);
-                angularVelocity.Y = Mathf.DegToRad(angularVelocity.Y);
-                angularVelocity.Z = Mathf.DegToRad(angularVelocity.Z);
+                Vector3 angularVelocity = Vector3.Zero;
+                angularVelocity.X = Mathf.DegToRad(angularVelocityDegrees.X);
+                angularVelocity.Y = Mathf.DegToRad(angularVelocityDegrees.Y);
+                angularVelocity.Z = Mathf.DegToRad(angularVelocityDegrees.Z);
 
-                body.SetMeta(CONSTANT_ANGULAR_VELOCITY_METADATA_NAME, angularVelocity);
+                SetMarkerMeta(CONSTANT_ANGULAR_VELOCITY_METADATA_NAME, angularVelocity);
             }
 
             if (body.HasMeta(CONSTANT_ANGULAR_VELOCITY_METADATA_NAME))

--- a/src/core/Levels/Level.cs
+++ b/src/core/Levels/Level.cs
@@ -116,7 +116,7 @@ namespace Jumpvalley.Levels
                 {
                     foreach (Node node in parentNode.GetChildren())
                     {
-                        if (node.HasMeta(InteractiveToolkit.INTERACTIVE_TYPE_METADATA_NAME))
+                        if (node.Name.ToString().StartsWith(InteractiveNode.NODE_MARKER_NAME_PREFIX))
                         {
                             string interactiveType = node.GetMeta(InteractiveToolkit.INTERACTIVE_TYPE_METADATA_NAME).As<string>();
 


### PR DESCRIPTION
This PR makes it so the metadata of Interactives is defined in a node that's a child of the Interactive's root node. The name of this child node should begin with `_Interactive`.

The metadata entry specifying the Interactive's type is now named `type` (previously, it was `interactive_type`).

Various bugs were also fixed along the way.