### PR TITLE
Customize acceleration/deceleration based on if the character wants to move and if the character is in the air

### DIFF
--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -135,6 +135,16 @@ namespace Jumpvalley.Players.Movement
         /// </summary>
         public float Deceleration = 16f;
 
+        /// <summary>
+        /// The deceleration that the character's XZ velocity decreases at when
+        /// in the air and one of these other conditions is true:
+        /// <list type="bullet">
+        /// <item>The character is trying to stop</item>
+        /// <item>The character has exceeded max speed</item>
+        /// </list>
+        /// </summary>
+        public float AirDeceleration = 1.6f;
+
         private float _speed;
 
         /// <summary>

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -117,12 +117,23 @@ namespace Jumpvalley.Players.Movement
         public float JumpVelocity = 5f;
 
         /// <summary>
-        /// The acceleration that the character's velocity changes at.
+        /// The acceleration that the character's XZ velocity increases at
+        /// while the character is trying to move.
         /// <br/>
         /// This doesn't affect upward and downward movement,
         /// and therefore, this only affects X and Z movement.
         /// </summary>
         public float Acceleration = 16f;
+
+        /// <summary>
+        /// The deceleration that the character's XZ velocity decreases at when
+        /// on the ground and one of these other conditions is true:
+        /// <list type="bullet">
+        /// <item>The character is trying to stop</item>
+        /// <item>The character has exceeded max speed</item>
+        /// </list>
+        /// </summary>
+        public float Deceleration = 16f;
 
         private float _speed;
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -621,7 +621,6 @@ namespace Jumpvalley.Players.Movement
             Vector2 xzVelocityDelta = direction * acceleration * physicsStepDelta;
 
             Vector2 finalVelocity = currentVelocity + new Vector2(xzVelocityDelta.X, xzVelocityDelta.Y);
-            finalVelocity.Y = goalVelocity.Y;
 
             // We don't want velocity changes to "overshoot" past the destination velocity.
             // Therefore, we'll have to snap the velocity to the goal velocity once it's time to do so.

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -129,7 +129,7 @@ namespace Jumpvalley.Players.Movement
         /// The acceleration that the character's XZ velocity increases at while
         /// in the air.
         /// </summary>
-        public float AirAcceleration = 1.6f;
+        public float AirAcceleration = 8f;
 
         /// <summary>
         /// The deceleration that the character's XZ velocity decreases at when
@@ -149,7 +149,7 @@ namespace Jumpvalley.Players.Movement
         /// <item>The character has exceeded max speed</item>
         /// </list>
         /// </summary>
-        public float AirDeceleration = 1.6f;
+        public float AirDeceleration = 8f;
 
         private float _speed;
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -463,7 +463,7 @@ namespace Jumpvalley.Players.Movement
                 // and "wanting to move backward" while climbing means we want to go down.
                 bool shouldApplyClimbVelocity = true;
 
-                if (IsTryingToMove())
+                if (!IsTryingToMove())
                 {
                     climbVelocity = 0;
                 }

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -118,12 +118,18 @@ namespace Jumpvalley.Players.Movement
 
         /// <summary>
         /// The acceleration that the character's XZ velocity increases at
-        /// while the character is trying to move.
+        /// while the character is trying to move on the ground.
         /// <br/>
         /// This doesn't affect upward and downward movement,
         /// and therefore, this only affects X and Z movement.
         /// </summary>
         public float Acceleration = 16f;
+
+        /// <summary>
+        /// The acceleration that the character's XZ velocity increases at while
+        /// in the air.
+        /// </summary>
+        public float AirAcceleration = 1.6f;
 
         /// <summary>
         /// The deceleration that the character's XZ velocity decreases at when
@@ -723,15 +729,24 @@ namespace Jumpvalley.Players.Movement
                 float acceleration = 0f;
                 bool isTryingToMove = IsTryingToMove();
                 bool hasExceededMaxSpeed = lastXZVelocity.Length() > Speed;
-                if (isTryingToMove && hasExceededMaxSpeed == false)
+                bool canMoveFaster = isTryingToMove && hasExceededMaxSpeed == false;
+
+                if (IsOnFloor())
                 {
-                    acceleration = Acceleration;
+                    if (canMoveFaster)
+                    {
+                        acceleration = Acceleration;
+                    }
+                    else
+                    {
+                        acceleration = Deceleration;
+                    }
                 }
                 else
                 {
-                    if (IsOnFloor())
+                    if (canMoveFaster)
                     {
-                        acceleration = Deceleration;
+                        acceleration = AirAcceleration;
                     }
                     else
                     {

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -112,7 +112,7 @@ namespace Jumpvalley.Players.Movement
         public float Gravity = 9.8f;
 
         /// <summary>
-        /// The initial velocity of the character's jump
+        /// The initial Y-velocity of the character's jump
         /// </summary>
         public float JumpVelocity = 5f;
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -403,7 +403,7 @@ namespace Jumpvalley.Players.Movement
         /// </returns>
         public bool IsTryingToMove()
         {
-            return ForwardValue == 0 && RightValue == 0;
+            return ForwardValue != 0 || RightValue != 0;
         }
 
         /// <summary>
@@ -713,13 +713,16 @@ namespace Jumpvalley.Players.Movement
                 }
 
                 // The velocity we want to approach
+                Vector3 lastVelocity = LastVelocity;
                 Vector3 moveVelocity = GetMoveVelocity(fDelta, yaw);
+
+                Vector2 lastXZVelocity = new Vector2(lastVelocity.X, lastVelocity.Z);
                 Vector2 goalXZVelocity = new Vector2(moveVelocity.X, moveVelocity.Z);
 
                 // Determine which value of acceleration to use
                 float acceleration = 0f;
                 bool isTryingToMove = IsTryingToMove();
-                bool hasExceededMaxSpeed = goalXZVelocity.Length() > Speed;
+                bool hasExceededMaxSpeed = lastXZVelocity.Length() > Speed;
                 if (isTryingToMove && hasExceededMaxSpeed == false)
                 {
                     acceleration = Acceleration;
@@ -739,9 +742,8 @@ namespace Jumpvalley.Players.Movement
                 // Apply acceleration
                 // Acceleration should be relative to the change in direction based
                 // on how the currently requested velocity differs from the previous velocity.
-                Vector3 lastVelocity = LastVelocity;
                 Vector2 newXZvelocity = ApproachXZVelocity(
-                    new Vector2(lastVelocity.X, lastVelocity.Z),
+                    lastXZVelocity,
                     goalXZVelocity,
                     acceleration,
                     fDelta

--- a/src/game/JumpvalleyPlayer.cs
+++ b/src/game/JumpvalleyPlayer.cs
@@ -70,6 +70,9 @@ namespace JumpvalleyGame
             Mover.JumpVelocity = 25f;
             Mover.Speed = 8f;
             Mover.Acceleration = 180f;
+            Mover.AirAcceleration = 90f;
+            Mover.Deceleration = 180f;
+            Mover.AirDeceleration = 90f;
 
             Mover.Body = Character;
 


### PR DESCRIPTION
This PR adds separate values to `BaseMover` for acceleration, deceleration, acceleration while in the air, and deceleration while in the air.

The character's acceleration and deceleration while in the air is now 90 m/s^2 (this value is different from the default found in `BaseMover`'s code).