### PR TITLE
Add Start-End Teleporter mechanic

### DIFF
--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -236,12 +236,8 @@ metadata/start_node_paths = [NodePath("../StartNodes/Start0"), NodePath("../Star
 
 [node name="StartNodes" type="Node3D" parent="Interactives/StartEndTeleporter"]
 
-[node name="Start0" type="RigidBody3D" parent="Interactives/StartEndTeleporter/StartNodes"]
+[node name="Start0" type="Area3D" parent="Interactives/StartEndTeleporter/StartNodes"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 9, 3.75, -10)
-freeze = true
-freeze_mode = 1
-max_contacts_reported = 50
-contact_monitor = true
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/StartEndTeleporter/StartNodes/Start0"]
 shape = SubResource("BoxShape3D_dv07x")

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -256,14 +256,17 @@ shape = SubResource("BoxShape3D_dv07x")
 material_override = SubResource("StandardMaterial3D_5jrae")
 mesh = SubResource("BoxMesh_mu0vs")
 
-[node name="Destination" type="RigidBody3D" parent="Interactives/StartEndTeleporter"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.5, 15.75, -20.5)
+[node name="Destination" type="Node3D" parent="Interactives/StartEndTeleporter"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.5, 16, -20.5)
+
+[node name="Platform" type="RigidBody3D" parent="Interactives/StartEndTeleporter/Destination"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.25, 0)
 freeze = true
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/StartEndTeleporter/Destination"]
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/StartEndTeleporter/Destination/Platform"]
 shape = SubResource("BoxShape3D_dv07x")
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="Interactives/StartEndTeleporter/Destination/CollisionShape3D"]
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Interactives/StartEndTeleporter/Destination/Platform/CollisionShape3D"]
 material_override = SubResource("StandardMaterial3D_yb2eo")
 mesh = SubResource("BoxMesh_mu0vs")
 

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -238,6 +238,9 @@ metadata/start_node_paths = [NodePath("../StartNodes/Start0"), NodePath("../Star
 
 [node name="Start0" type="RigidBody3D" parent="Interactives/StartEndTeleporter/StartNodes"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 9, 3.75, -10)
+freeze = true
+max_contacts_reported = 1
+contact_monitor = true
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/StartEndTeleporter/StartNodes/Start0"]
 shape = SubResource("BoxShape3D_dv07x")
@@ -248,6 +251,9 @@ mesh = SubResource("BoxMesh_mu0vs")
 
 [node name="Start1" type="RigidBody3D" parent="Interactives/StartEndTeleporter/StartNodes"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 31.5, 6.75, -35)
+freeze = true
+max_contacts_reported = 1
+contact_monitor = true
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/StartEndTeleporter/StartNodes/Start1"]
 shape = SubResource("BoxShape3D_dv07x")
@@ -258,6 +264,7 @@ mesh = SubResource("BoxMesh_mu0vs")
 
 [node name="Destination" type="RigidBody3D" parent="Interactives/StartEndTeleporter"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.5, 15.75, -20.5)
+freeze = true
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/StartEndTeleporter/Destination"]
 shape = SubResource("BoxShape3D_dv07x")

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=37 format=3 uid="uid://dqjghdruydyeo"]
+[gd_scene load_steps=42 format=3 uid="uid://dqjghdruydyeo"]
 
 [ext_resource type="Material" uid="uid://bq3d6llinnd1i" path="res://textures/moveable_object_indicator.tres" id="1_x3ong"]
 [ext_resource type="Texture2D" uid="uid://d0tpyep45doca" path="res://addons/kenney_prototype_textures/light/texture_07.png" id="2_065hl"]
@@ -38,6 +38,26 @@ size = Vector3(1, 1, 10)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_jpkqu"]
 size = Vector3(1, 1, 10)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_dv07x"]
+size = Vector3(1, 0.5, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_vqo4w"]
+emission_enabled = true
+emission = Color(1, 1, 1, 1)
+
+[sub_resource type="BoxMesh" id="BoxMesh_mu0vs"]
+size = Vector3(1, 0.5, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_5jrae"]
+albedo_color = Color(0.419608, 0.356863, 1, 1)
+emission_enabled = true
+emission = Color(0.419608, 0.356863, 1, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_yb2eo"]
+albedo_color = Color(1, 0.862745, 0.360784, 1)
+emission_enabled = true
+emission = Color(1, 0.862745, 0.360784, 1)
 
 [sub_resource type="BoxMesh" id="BoxMesh_rmlu0"]
 
@@ -204,6 +224,47 @@ metadata/type = "Teleporter"
 metadata/should_set_rotation = true
 metadata/teleports_on_top = true
 metadata/destination_node_path = NodePath("..")
+
+[node name="StartEndTeleporter" type="Node3D" parent="Interactives"]
+
+[node name="_Interactive" type="Node" parent="Interactives/StartEndTeleporter"]
+metadata/type = "StartEndTeleporter"
+metadata/should_set_rotation = true
+metadata/teleports_on_top = true
+metadata/destination_node_path = NodePath("..")
+metadata/StartNodes = [NodePath(""), NodePath("")]
+
+[node name="StartNodes" type="Node3D" parent="Interactives/StartEndTeleporter"]
+
+[node name="Start0" type="RigidBody3D" parent="Interactives/StartEndTeleporter/StartNodes"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 9, 3.75, -10)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/StartEndTeleporter/StartNodes/Start0"]
+shape = SubResource("BoxShape3D_dv07x")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Interactives/StartEndTeleporter/StartNodes/Start0/CollisionShape3D"]
+material_override = SubResource("StandardMaterial3D_vqo4w")
+mesh = SubResource("BoxMesh_mu0vs")
+
+[node name="Start1" type="RigidBody3D" parent="Interactives/StartEndTeleporter/StartNodes"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 31.5, 6.75, -35)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/StartEndTeleporter/StartNodes/Start1"]
+shape = SubResource("BoxShape3D_dv07x")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Interactives/StartEndTeleporter/StartNodes/Start1/CollisionShape3D"]
+material_override = SubResource("StandardMaterial3D_5jrae")
+mesh = SubResource("BoxMesh_mu0vs")
+
+[node name="Destination" type="RigidBody3D" parent="Interactives/StartEndTeleporter"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.5, 15.75, -20.5)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/StartEndTeleporter/Destination"]
+shape = SubResource("BoxShape3D_dv07x")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Interactives/StartEndTeleporter/Destination/CollisionShape3D"]
+material_override = SubResource("StandardMaterial3D_yb2eo")
+mesh = SubResource("BoxMesh_mu0vs")
 
 [node name="SpinningMesh" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, -8)

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -233,6 +233,7 @@ metadata/should_set_rotation = true
 metadata/teleports_on_top = true
 metadata/destination_node_path = NodePath("../Destination")
 metadata/start_node_paths = [NodePath("../StartNodes/Start0"), NodePath("../StartNodes/Start1")]
+metadata/teleports_player = false
 
 [node name="StartNodes" type="Node3D" parent="Interactives/StartEndTeleporter"]
 

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -232,7 +232,7 @@ metadata/type = "StartEndTeleporter"
 metadata/should_set_rotation = true
 metadata/teleports_on_top = true
 metadata/destination_node_path = NodePath("..")
-metadata/StartNodes = [NodePath(""), NodePath("")]
+metadata/start_nodes = [NodePath("../StartNodes/Start0"), NodePath("../StartNodes/Start1")]
 
 [node name="StartNodes" type="Node3D" parent="Interactives/StartEndTeleporter"]
 

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -246,11 +246,8 @@ shape = SubResource("BoxShape3D_dv07x")
 material_override = SubResource("StandardMaterial3D_vqo4w")
 mesh = SubResource("BoxMesh_mu0vs")
 
-[node name="Start1" type="RigidBody3D" parent="Interactives/StartEndTeleporter/StartNodes"]
+[node name="Start1" type="Area3D" parent="Interactives/StartEndTeleporter/StartNodes"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 31.5, 6.75, -35)
-freeze = true
-max_contacts_reported = 50
-contact_monitor = true
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/StartEndTeleporter/StartNodes/Start1"]
 shape = SubResource("BoxShape3D_dv07x")

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -231,7 +231,7 @@ metadata/destination_node_path = NodePath("..")
 metadata/type = "StartEndTeleporter"
 metadata/should_set_rotation = true
 metadata/teleports_on_top = true
-metadata/destination_node_path = NodePath("..")
+metadata/destination_node_path = NodePath("../Destination")
 metadata/start_node_paths = [NodePath("../StartNodes/Start0"), NodePath("../StartNodes/Start1")]
 
 [node name="StartNodes" type="Node3D" parent="Interactives/StartEndTeleporter"]

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -239,6 +239,7 @@ metadata/start_node_paths = [NodePath("../StartNodes/Start0"), NodePath("../Star
 [node name="Start0" type="RigidBody3D" parent="Interactives/StartEndTeleporter/StartNodes"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 9, 3.75, -10)
 freeze = true
+freeze_mode = 1
 max_contacts_reported = 50
 contact_monitor = true
 

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -239,7 +239,7 @@ metadata/start_node_paths = [NodePath("../StartNodes/Start0"), NodePath("../Star
 [node name="Start0" type="RigidBody3D" parent="Interactives/StartEndTeleporter/StartNodes"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 9, 3.75, -10)
 freeze = true
-max_contacts_reported = 1
+max_contacts_reported = 50
 contact_monitor = true
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/StartEndTeleporter/StartNodes/Start0"]
@@ -252,7 +252,7 @@ mesh = SubResource("BoxMesh_mu0vs")
 [node name="Start1" type="RigidBody3D" parent="Interactives/StartEndTeleporter/StartNodes"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 31.5, 6.75, -35)
 freeze = true
-max_contacts_reported = 1
+max_contacts_reported = 50
 contact_monitor = true
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/StartEndTeleporter/StartNodes/Start1"]

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -233,7 +233,7 @@ metadata/should_set_rotation = true
 metadata/teleports_on_top = true
 metadata/destination_node_path = NodePath("../Destination")
 metadata/start_node_paths = [NodePath("../StartNodes/Start0"), NodePath("../StartNodes/Start1")]
-metadata/teleports_player = false
+metadata/teleports_player = true
 
 [node name="StartNodes" type="Node3D" parent="Interactives/StartEndTeleporter"]
 

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -232,7 +232,7 @@ metadata/type = "StartEndTeleporter"
 metadata/should_set_rotation = true
 metadata/teleports_on_top = true
 metadata/destination_node_path = NodePath("..")
-metadata/start_nodes = [NodePath("../StartNodes/Start0"), NodePath("../StartNodes/Start1")]
+metadata/start_node_paths = [NodePath("../StartNodes/Start0"), NodePath("../StartNodes/Start1")]
 
 [node name="StartNodes" type="Node3D" parent="Interactives/StartEndTeleporter"]
 

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -11,6 +11,7 @@ size = Vector3(1, 2, 0.5)
 
 [node name="Character" type="CharacterBody3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+metadata/custom_overall_bounding_box = AABB(-0.5, -1, -0.25, 1, 2, 0.5)
 
 [node name="_InteractiveBoundingBox" type="Node" parent="."]
 metadata/type = "OverallBoundingBoxObject"

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -12,6 +12,9 @@ size = Vector3(1, 2, 0.5)
 [node name="Character" type="CharacterBody3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 
+[node name="_InteractiveBoundingBox" type="Node" parent="."]
+metadata/type = "OverallBoundingBoxObject"
+
 [node name="RootCollider" type="CollisionShape3D" parent="."]
 shape = SubResource("BoxShape3D_s2be1")
 

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -14,6 +14,7 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
     public partial class StartEndTeleporter : Teleporter
     {
         private static readonly string START_NODE_PATHS_META_NAME = "start_node_paths";
+        private static readonly string TELEPORTS_PLAYER_META_NAME = "teleports_player";
 
         /// <summary>
         /// The list of node paths to the teleporter's start nodes.
@@ -35,6 +36,21 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
         /// Nodes that can be teleported by this <see cref="StartEndTeleporter"/> 
         /// </summary>
         public List<Node3D> NodesToTeleport { get; private set; }
+        
+        private bool _teleportsPlayer;
+
+        /// <summary>
+        /// Whether or not to teleport the player's character
+        /// </summary>
+        public bool TeleportsPlayer
+        {
+            get => _teleportsPlayer;
+            set
+            {
+                _teleportsPlayer = value;
+                SetMarkerMeta(TELEPORTS_PLAYER_META_NAME, value);
+            }
+        }
 
         public StartEndTeleporter(OffsetStopwatch stopwatch, Node marker) : base(stopwatch, marker)
         {
@@ -55,6 +71,12 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
                 }
 
                 PopulateStartNodesList();
+            }
+
+            bool teleportsPlayer;
+            if (TryGetMarkerMeta<bool>(TELEPORTS_PLAYER_META_NAME, out teleportsPlayer))
+            {
+                TeleportsPlayer = teleportsPlayer;
             }
         }
 

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -20,6 +20,11 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
         /// </summary>
         public List<NodePath> StartNodePaths { get; private set; }
 
+        /// <summary>
+        /// Nodes that can be teleported by this <see cref="StartEndTeleporter"/> 
+        /// </summary>
+        public List<Node> NodesToTeleport;
+
         public StartEndTeleporter(OffsetStopwatch stopwatch, Node marker) : base(stopwatch, marker)
         {
             StartNodePaths = new List<NodePath>();

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -93,6 +93,7 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
             System.Console.WriteLine(body.Name);
             if (NodesToTeleport.Contains(body))
             {
+                System.Console.WriteLine($"Teleporting {body.Name} to {GetDestinationPoint(body)}");
                 SendToDestination(body);
             }
         }

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -31,7 +31,7 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
         /// will get teleported by this <see cref="StartEndTeleporter"/>
         /// when they touch a node in this list.
         /// </summary>
-        public List<Node3D> StartNodes { get; private set; }
+        public List<Area3D> StartNodes { get; private set; }
 
         /// <summary>
         /// Nodes that can be teleported by this <see cref="StartEndTeleporter"/> 
@@ -56,7 +56,7 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
         public StartEndTeleporter(OffsetStopwatch stopwatch, Node marker) : base(stopwatch, marker)
         {
             StartNodePaths = new List<NodePath>();
-            StartNodes = new List<Node3D>();
+            StartNodes = new List<Area3D>();
             NodesToTeleport = new List<Node3D>();
 
             Array startNodesMetadata;
@@ -148,7 +148,7 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
 
             base.Start();
 
-            foreach (Node3D node in StartNodes)
+            foreach (Area3D node in StartNodes)
             {
                 if (node is Area3D area)
                 {
@@ -163,7 +163,7 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
 
             base.Stop();
 
-            foreach (Node3D node in StartNodes)
+            foreach (Area3D node in StartNodes)
             {
                 if (node is Area3D area)
                 {

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -96,6 +96,8 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
 
         public override void Stop()
         {
+            if (!IsRunning) return;
+
             base.Stop();
 
             foreach (RigidBody3D body in StartNodes)

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -80,10 +80,10 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
         {
             foreach (NodePath path in StartNodePaths)
             {
-                RigidBody3D rigidBody = NodeMarker.GetNode<RigidBody3D>(path);
-                if (rigidBody != null)
+                Area3D area = NodeMarker.GetNode<Area3D>(path);
+                if (area != null)
                 {
-                    StartNodes.Add(rigidBody);
+                    StartNodes.Add(area);
                 }
             }
         }

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -56,6 +56,24 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
             }
         }
 
+        /// <summary>
+        /// Removes a node from the <see cref="NodesToTeleport"/> list
+        /// </summary>
+        /// <param name="node">The node to remove</param>
+        public void RemoveNodeToTeleport(Node node)
+        {
+            NodesToTeleport.Remove(node);
+        }
+
+        /// <summary>
+        /// Adds a node to the <see cref="NodesToTeleport"/> list
+        /// </summary>
+        /// <param name="node">The node to add</param>
+        public void AddNodeToTeleport(Node node)
+        {
+            if (!NodesToTeleport.Contains(node)) NodesToTeleport.Add(node);
+        }
+
         private void PopulateStartNodesList()
         {
             foreach (NodePath path in StartNodePaths)

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -71,7 +71,7 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
         /// <param name="node">The node to add</param>
         public void AddNodeToTeleport(Node node)
         {
-            if (!NodesToTeleport.Contains(node)) NodesToTeleport.Add(node);
+            if (node != null && NodesToTeleport.Contains(node) == false) NodesToTeleport.Add(node);
         }
 
         private void PopulateStartNodesList()

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Godot;
 using Godot.Collections;
+using Jumpvalley.Players;
 using Jumpvalley.Timing;
 
 namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
@@ -110,6 +111,21 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
             }
         }
 
+        private CharacterBody3D GetPlayerCharacter()
+        {
+            if (Runner is Level level && level != null)
+            {
+                Player player = level.GetCurrentPlayer();
+
+                if (player != null)
+                {
+                    return player.Character;
+                }
+            }
+
+            return null;
+        }
+
         private void HandleStartNodeTouch(Node3D body)
         {
             System.Console.WriteLine(body.Name);
@@ -117,6 +133,15 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
             {
                 System.Console.WriteLine($"Teleporting {body.Name} to {GetDestinationPoint(body)}");
                 SendToDestination(body);
+            }
+            else if (TeleportsPlayer)
+            {
+                CharacterBody3D character = GetPlayerCharacter();
+                if (body == character)
+                {
+                    System.Console.WriteLine($"Teleporting character to {GetDestinationPoint(body)}");
+                    SendToDestination(body);
+                }
             }
         }
 

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -90,5 +90,15 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
                 body.BodyEntered += HandleStartNodeTouch;
             }
         }
+
+        public override void Stop()
+        {
+            base.Stop();
+
+            foreach (RigidBody3D body in StartNodes)
+            {
+                body.BodyEntered -= HandleStartNodeTouch;
+            }
+        }
     }
 }

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -1,0 +1,17 @@
+using Godot;
+using Jumpvalley.Timing;
+
+namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
+{
+    /// <summary>
+    /// Type of teleporter that teleports a node to <see cref="Teleporter.Destination"/>
+    /// when the node touches specified parts.
+    /// </summary>
+    public partial class StartEndTeleporter : Teleporter
+    {
+        public StartEndTeleporter(OffsetStopwatch stopwatch, Node marker) : base(stopwatch, marker)
+        {
+
+        }
+    }
+}

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -27,7 +27,7 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
         /// will get teleported by this <see cref="StartEndTeleporter"/>
         /// when they touch a node in this list.
         /// </summary>
-        public List<RigidBody3D> StartNodes { get; private set; }
+        public List<Node> StartNodes { get; private set; }
 
         /// <summary>
         /// Nodes that can be teleported by this <see cref="StartEndTeleporter"/> 
@@ -37,7 +37,7 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
         public StartEndTeleporter(OffsetStopwatch stopwatch, Node marker) : base(stopwatch, marker)
         {
             StartNodePaths = new List<NodePath>();
-            StartNodes = new List<RigidBody3D>();
+            StartNodes = new List<Node>();
             NodesToTeleport = new List<Node>();
 
             Array startNodesMetadata;
@@ -85,9 +85,12 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
 
             base.Start();
 
-            foreach (RigidBody3D body in StartNodes)
+            foreach (Node node in StartNodes)
             {
-                body.BodyEntered += HandleStartNodeTouch;
+                if (node is RigidBody3D body)
+                {
+                    body.BodyEntered += HandleStartNodeTouch;
+                }
             }
         }
 

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using Godot;
+using Godot.Collections;
 using Jumpvalley.Timing;
 
 namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
@@ -9,9 +11,25 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
     /// </summary>
     public partial class StartEndTeleporter : Teleporter
     {
+        private static readonly string START_NODE_PATHS_META_NAME = "start_node_paths";
+        public List<NodePath> StartNodePaths { get; private set; }
+
         public StartEndTeleporter(OffsetStopwatch stopwatch, Node marker) : base(stopwatch, marker)
         {
+            StartNodePaths = new List<NodePath>();
 
+            Array startNodesMetadata;
+            if (TryGetMarkerMeta<Array>(START_NODE_PATHS_META_NAME, out startNodesMetadata))
+            {
+                foreach (Variant item in startNodesMetadata)
+                {
+                    NodePath path = item.As<NodePath>();
+                    if (path != null)
+                    {
+                        StartNodePaths.Add(path);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -7,12 +7,14 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
 {
     /// <summary>
     /// Type of teleporter that teleports a node to <see cref="Teleporter.Destination"/>
-    /// when the node touches specified parts.
+    /// when the node touches specified parts called start nodes.
+    /// <br/><br/>
+    /// Start nodes should be <see cref="Area3D"/>s.  
     /// </summary>
     public partial class StartEndTeleporter : Teleporter
     {
         private static readonly string START_NODE_PATHS_META_NAME = "start_node_paths";
-        
+
         /// <summary>
         /// The list of node paths to the teleporter's start nodes.
         /// These paths should be relative to <see cref="InteractiveNode.NodeMarker"/>.
@@ -27,18 +29,18 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
         /// will get teleported by this <see cref="StartEndTeleporter"/>
         /// when they touch a node in this list.
         /// </summary>
-        public List<Node> StartNodes { get; private set; }
+        public List<Node3D> StartNodes { get; private set; }
 
         /// <summary>
         /// Nodes that can be teleported by this <see cref="StartEndTeleporter"/> 
         /// </summary>
-        public List<Node> NodesToTeleport { get; private set; }
+        public List<Node3D> NodesToTeleport { get; private set; }
 
         public StartEndTeleporter(OffsetStopwatch stopwatch, Node marker) : base(stopwatch, marker)
         {
             StartNodePaths = new List<NodePath>();
-            StartNodes = new List<Node>();
-            NodesToTeleport = new List<Node>();
+            StartNodes = new List<Node3D>();
+            NodesToTeleport = new List<Node3D>();
 
             Array startNodesMetadata;
             if (TryGetMarkerMeta<Array>(START_NODE_PATHS_META_NAME, out startNodesMetadata))
@@ -60,7 +62,7 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
         /// Removes a node from the <see cref="NodesToTeleport"/> list
         /// </summary>
         /// <param name="node">The node to remove</param>
-        public void RemoveNodeToTeleport(Node node)
+        public void RemoveNodeToTeleport(Node3D node)
         {
             NodesToTeleport.Remove(node);
         }
@@ -69,7 +71,7 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
         /// Adds a node to the <see cref="NodesToTeleport"/> list
         /// </summary>
         /// <param name="node">The node to add</param>
-        public void AddNodeToTeleport(Node node)
+        public void AddNodeToTeleport(Node3D node)
         {
             if (node != null && NodesToTeleport.Contains(node) == false) NodesToTeleport.Add(node);
         }
@@ -86,15 +88,12 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
             }
         }
 
-        private void HandleStartNodeTouch(Node body)
+        private void HandleStartNodeTouch(Node3D body)
         {
             System.Console.WriteLine(body.Name);
             if (NodesToTeleport.Contains(body))
             {
-                if (body is Node3D node3d)
-                {
-                    SendToDestination(node3d);
-                }
+                SendToDestination(body);
             }
         }
 
@@ -104,11 +103,11 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
 
             base.Start();
 
-            foreach (Node node in StartNodes)
+            foreach (Node3D node in StartNodes)
             {
-                if (node is RigidBody3D body)
+                if (node is Area3D area)
                 {
-                    body.BodyEntered += HandleStartNodeTouch;
+                    area.BodyEntered += HandleStartNodeTouch;
                 }
             }
         }
@@ -119,9 +118,12 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
 
             base.Stop();
 
-            foreach (RigidBody3D body in StartNodes)
+            foreach (Node3D node in StartNodes)
             {
-                body.BodyEntered -= HandleStartNodeTouch;
+                if (node is Area3D area)
+                {
+                    area.BodyEntered -= HandleStartNodeTouch;
+                }
             }
         }
     }

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -37,7 +37,7 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
         /// Nodes that can be teleported by this <see cref="StartEndTeleporter"/> 
         /// </summary>
         public List<Node3D> NodesToTeleport { get; private set; }
-        
+
         private bool _teleportsPlayer;
 
         /// <summary>
@@ -128,10 +128,8 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
 
         private void HandleStartNodeTouch(Node3D body)
         {
-            System.Console.WriteLine(body.Name);
             if (NodesToTeleport.Contains(body))
             {
-                System.Console.WriteLine($"Teleporting {body.Name} to {GetDestinationPoint(body)}");
                 SendToDestination(body);
             }
             else if (TeleportsPlayer)
@@ -139,7 +137,6 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
                 CharacterBody3D character = GetPlayerCharacter();
                 if (body == character)
                 {
-                    System.Console.WriteLine($"Teleporting character to {GetDestinationPoint(body)}");
                     SendToDestination(body);
                 }
             }

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -68,11 +68,27 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
             }
         }
 
+        private void HandleStartNodeTouch(Node body)
+        {
+            if (NodesToTeleport.Contains(body))
+            {
+                if (body is Node3D node3d)
+                {
+                    SendToDestination(node3d);
+                }
+            }
+        }
+
         public override void Start()
         {
             if (IsRunning) return;
 
             base.Start();
+
+            foreach (RigidBody3D body in StartNodes)
+            {
+                body.BodyEntered += HandleStartNodeTouch;
+            }
         }
     }
 }

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -12,6 +12,12 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
     public partial class StartEndTeleporter : Teleporter
     {
         private static readonly string START_NODE_PATHS_META_NAME = "start_node_paths";
+        
+        /// <summary>
+        /// The list of node paths to the teleporter's start nodes.
+        /// Obtained from <see cref="InteractiveNode.NodeMarker"/>'s
+        /// <c>start_node_paths</c> metadata entry.
+        /// </summary>
         public List<NodePath> StartNodePaths { get; private set; }
 
         public StartEndTeleporter(OffsetStopwatch stopwatch, Node marker) : base(stopwatch, marker)

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -88,6 +88,7 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
 
         private void HandleStartNodeTouch(Node body)
         {
+            System.Console.WriteLine(body.Name);
             if (NodesToTeleport.Contains(body))
             {
                 if (body is Node3D node3d)

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -15,19 +15,30 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
         
         /// <summary>
         /// The list of node paths to the teleporter's start nodes.
+        /// These paths should be relative to <see cref="InteractiveNode.NodeMarker"/>.
+        /// <br/><br/>
         /// Obtained from <see cref="InteractiveNode.NodeMarker"/>'s
         /// <c>start_node_paths</c> metadata entry.
         /// </summary>
         public List<NodePath> StartNodePaths { get; private set; }
 
         /// <summary>
+        /// The list of start nodes. Nodes in <see cref="NodesToTeleport"/>
+        /// will get teleported by this <see cref="StartEndTeleporter"/>
+        /// when they touch a node in this list.
+        /// </summary>
+        public List<RigidBody3D> StartNodes { get; private set; }
+
+        /// <summary>
         /// Nodes that can be teleported by this <see cref="StartEndTeleporter"/> 
         /// </summary>
-        public List<Node> NodesToTeleport;
+        public List<Node> NodesToTeleport { get; private set; }
 
         public StartEndTeleporter(OffsetStopwatch stopwatch, Node marker) : base(stopwatch, marker)
         {
             StartNodePaths = new List<NodePath>();
+            StartNodes = new List<RigidBody3D>();
+            NodesToTeleport = new List<Node>();
 
             Array startNodesMetadata;
             if (TryGetMarkerMeta<Array>(START_NODE_PATHS_META_NAME, out startNodesMetadata))
@@ -40,7 +51,28 @@ namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
                         StartNodePaths.Add(path);
                     }
                 }
+
+                PopulateStartNodesList();
             }
+        }
+
+        private void PopulateStartNodesList()
+        {
+            foreach (NodePath path in StartNodePaths)
+            {
+                RigidBody3D rigidBody = NodeMarker.GetNode<RigidBody3D>(path);
+                if (rigidBody != null)
+                {
+                    StartNodes.Add(rigidBody);
+                }
+            }
+        }
+
+        public override void Start()
+        {
+            if (IsRunning) return;
+
+            base.Start();
         }
     }
 }

--- a/src/core/Levels/Level.cs
+++ b/src/core/Levels/Level.cs
@@ -177,16 +177,6 @@ namespace Jumpvalley.Levels
         {
             string interactiveType = InteractiveNode.GetTypeNameFromMarker(nodeMarker);
 
-            CharacterBody3D character = null;
-            if (Runner is LevelRunner levelRunner && levelRunner != null)
-            {
-                Player player = levelRunner.CurrentPlayer;
-                if (player != null)
-                {
-                    character = player.Character;
-                }
-            }
-
             Interactive interactive = null;
 
             if (interactiveType.Equals("Spinner"))
@@ -202,8 +192,6 @@ namespace Jumpvalley.Levels
             else if (interactiveType.Equals("StartEndTeleporter"))
             {
                 StartEndTeleporter teleporter = new StartEndTeleporter(Clock, nodeMarker);
-                teleporter.AddNodeToTeleport(character);
-
                 interactive = teleporter;
             }
 

--- a/src/core/Levels/Level.cs
+++ b/src/core/Levels/Level.cs
@@ -171,6 +171,11 @@ namespace Jumpvalley.Levels
                 Teleporter teleporter = new Teleporter(Clock, nodeMarker);
                 interactive = teleporter;
             }
+            else if (interactiveType.Equals("StartEndTeleporter"))
+            {
+                StartEndTeleporter teleporter = new StartEndTeleporter(Clock, nodeMarker);
+                interactive = teleporter;
+            }
 
             // If the interactive's type is recognized,
             // let it know that this level is running it,

--- a/src/core/Levels/Level.cs
+++ b/src/core/Levels/Level.cs
@@ -160,6 +160,16 @@ namespace Jumpvalley.Levels
         {
             string interactiveType = InteractiveNode.GetTypeNameFromMarker(nodeMarker);
 
+            CharacterBody3D character = null;
+            if (Runner is LevelRunner levelRunner && levelRunner != null)
+            {
+                Player player = levelRunner.CurrentPlayer;
+                if (player != null)
+                {
+                    character = player.Character;
+                }
+            }
+
             Interactive interactive = null;
 
             if (interactiveType.Equals("Spinner"))
@@ -170,6 +180,13 @@ namespace Jumpvalley.Levels
             else if (interactiveType.Equals("Teleporter"))
             {
                 Teleporter teleporter = new Teleporter(Clock, nodeMarker);
+                interactive = teleporter;
+            }
+            else if (interactiveType.Equals("StartEndTeleporter"))
+            {
+                StartEndTeleporter teleporter = new StartEndTeleporter(Clock, nodeMarker);
+                teleporter.AddNodeToTeleport(character);
+
                 interactive = teleporter;
             }
 

--- a/src/core/Levels/Level.cs
+++ b/src/core/Levels/Level.cs
@@ -101,7 +101,8 @@ namespace Jumpvalley.Levels
         /// <param name="info">Info about the level</param>
         /// <param name="root">The root node of the level to represent</param>
         /// <param name="lastElapsedTime">The most recent amount of elapsed running time that the level left off of</param>
-        public Level(LevelInfo info, Node root, TimeSpan lastElapsedTime) : base(new OffsetStopwatch(lastElapsedTime))
+        /// <param name="runner">The object that's running this level. Typically, this should be a <see cref="LevelRunner"/>.</param>
+        public Level(LevelInfo info, Node root, TimeSpan lastElapsedTime, object runner) : base(new OffsetStopwatch(lastElapsedTime), runner)
         {
             Info = info;
             RootNode = root;

--- a/src/core/Levels/Level.cs
+++ b/src/core/Levels/Level.cs
@@ -159,6 +159,16 @@ namespace Jumpvalley.Levels
         {
             string interactiveType = InteractiveNode.GetTypeNameFromMarker(nodeMarker);
 
+            CharacterBody3D character = null;
+            if (Runner is LevelRunner levelRunner && levelRunner != null)
+            {
+                Player player = levelRunner.CurrentPlayer;
+                if (player != null)
+                {
+                    character = player.Character;
+                }
+            }
+
             Interactive interactive = null;
 
             if (interactiveType.Equals("Spinner"))
@@ -174,6 +184,8 @@ namespace Jumpvalley.Levels
             else if (interactiveType.Equals("StartEndTeleporter"))
             {
                 StartEndTeleporter teleporter = new StartEndTeleporter(Clock, nodeMarker);
+                teleporter.AddNodeToTeleport(character);
+
                 interactive = teleporter;
             }
 

--- a/src/game/JumpvalleyPlayer.cs
+++ b/src/game/JumpvalleyPlayer.cs
@@ -13,6 +13,7 @@ using JumpvalleyGame.Gui;
 using JumpvalleyGame.Levels;
 using JumpvalleyGame.Settings;
 using JumpvalleyGame.Testing;
+using Jumpvalley.Levels.Interactives.Mechanics;
 
 namespace JumpvalleyGame
 {
@@ -61,6 +62,10 @@ namespace JumpvalleyGame
             }
 
             //CurrentMusicPlayer.IsPlaying = true;
+
+            // Character bounding box
+            OverallBoundingBoxObject characterBoundingBox = new OverallBoundingBoxObject(Clock, Character.GetNode("_InteractiveBoundingBox"));
+            Disposables.Add(characterBoundingBox);
 
             // Set up character movement
             // Some values here are based on Juke's Towers of Hell physics (or somewhere close), except we're working with meters.


### PR DESCRIPTION
This new mechanic teleports 3D nodes from specified start 3D nodes to a specified destination.

To make teleporting the player's character work properly, a custom overall bounding box has been defined for it in this PR.