### PR TITLE
Parent interactive node handler to interactive node marker

### DIFF
--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -33,9 +33,6 @@ namespace Jumpvalley.Levels.Interactives
         /// <summary>
         /// Whether or not this interactive node handler is parented to
         /// <see cref="NodeMarker"/>.
-        /// <br/><br/>
-        /// Doing so allows accessing the interactive node's
-        /// handler from <see cref="NodeMarker"/>.
         /// </summary>
         public bool ParentedToNodeMarker
         {

--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -71,6 +71,7 @@ namespace Jumpvalley.Levels.Interactives
             if (nodeMarker == null) throw new ArgumentNullException(nameof(nodeMarker));
 
             NodeMarker = nodeMarker;
+            ParentedToNodeMarker = false;
         }
 
         /// <summary>

--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -28,6 +28,8 @@ namespace Jumpvalley.Levels.Interactives
         /// </summary>
         public Node RootNode => NodeMarker.GetParent();
 
+        private bool _parentedToNodeMarker;
+
         /// <summary>
         /// Whether or not this interactive node handler is parented to
         /// <see cref="NodeMarker"/>.
@@ -35,7 +37,32 @@ namespace Jumpvalley.Levels.Interactives
         /// Doing so allows accessing the interactive node's
         /// handler from <see cref="NodeMarker"/>.
         /// </summary>
-        public bool ParentedToNodeMarker;
+        public bool ParentedToNodeMarker
+        {
+            get => _parentedToNodeMarker;
+            set
+            {
+                _parentedToNodeMarker = value;
+
+                Node oldParent = GetParent();
+                if (value)
+                {
+                    if (oldParent != null)
+                    {
+                        oldParent.RemoveChild(this);
+                    }
+
+                    NodeMarker.AddChild(this);
+                }
+                else
+                {
+                    if (oldParent == NodeMarker)
+                    {
+                        NodeMarker.RemoveChild(this);
+                    }
+                }
+            }
+        }
 
         /// <summary>
         /// Creates a new instance of <see cref="InteractiveNode"/> for a given <see cref="Stopwatch"/> and <see cref="Node"/>

--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -29,6 +29,15 @@ namespace Jumpvalley.Levels.Interactives
         public Node RootNode => NodeMarker.GetParent();
 
         /// <summary>
+        /// Whether or not this interactive node handler is parented to
+        /// <see cref="NodeMarker"/>.
+        /// <br/><br/>
+        /// Doing so allows accessing the interactive node's
+        /// handler from <see cref="NodeMarker"/>.
+        /// </summary>
+        public bool ParentedToNodeMarker;
+
+        /// <summary>
         /// Creates a new instance of <see cref="InteractiveNode"/> for a given <see cref="Stopwatch"/> and <see cref="Node"/>
         /// </summary>
         /// <param name="stopwatch">The stopwatch to bind the interactive to</param>

--- a/src/core/Levels/Interactives/Mechanics/Spinner.cs
+++ b/src/core/Levels/Interactives/Mechanics/Spinner.cs
@@ -111,7 +111,6 @@ namespace Jumpvalley.Levels.Interactives.Mechanics
             originalConstantAngularVelocity = body.ConstantAngularVelocity;
 
             body.ConstantAngularVelocity = ConstantAngularVelocity;
-            body.AddChild(this);
         }
 
         public override void Stop()
@@ -119,7 +118,6 @@ namespace Jumpvalley.Levels.Interactives.Mechanics
             if (!IsRunning) return;
 
             base.Stop();
-            body.RemoveChild(this);
             body.ConstantAngularVelocity = originalConstantAngularVelocity;
         }
 

--- a/src/core/Levels/Level.cs
+++ b/src/core/Levels/Level.cs
@@ -202,6 +202,11 @@ namespace Jumpvalley.Levels
             {
                 interactive.Runner = this;
                 Interactives.Add(interactive);
+                
+                if (interactive is InteractiveNode interactiveNode)
+                {
+                    interactiveNode.ParentedToNodeMarker = true;
+                }
             }
         }
 


### PR DESCRIPTION
This PR adds an option to `InteractiveNode` to parent the corresponding interactive node's handler to the interactive node's marker.

Interactive node handlers created via the `Level` class have this option set to true in the default implementation of the `Level.InitializeInteractive` method.