### PR TITLE
Add initialization_lobby metadata entry

### DIFF
--- a/levels/demo_platformer/level.tscn
+++ b/levels/demo_platformer/level.tscn
@@ -39,6 +39,22 @@ size = Vector3(50, 100, 50)
 
 [node name="DemoPlatformer" type="Node3D"]
 
+[node name="Checkpoints" type="Node3D" parent="."]
+
+[node name="_Interactive" type="Node" parent="Checkpoints"]
+metadata/type = "CheckpointSet"
+metadata/checkpoints = [NodePath("../Start/_Interactive")]
+metadata/current_checkpoint = 0
+
+[node name="Start" type="Node3D" parent="Checkpoints"]
+transform = Transform3D(-1, 0, 8.74228e-08, 0, 1, 0, -8.74228e-08, 0, -1, 0, 0.5, -6)
+
+[node name="_Interactive" type="Node" parent="Checkpoints/Start"]
+metadata/type = "Teleporter"
+metadata/should_set_rotation = true
+metadata/teleports_on_top = true
+metadata/destination_node_path = NodePath("..")
+
 [node name="Interactives" type="Node3D" parent="."]
 
 [node name="InteractiveRootNode" type="Node3D" parent="Interactives"]

--- a/main.tscn
+++ b/main.tscn
@@ -85,6 +85,7 @@ transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, -3, 1.
 
 [node name="Levels" type="Node3D" parent="."]
 metadata/initialization_level = "res://levels/shape_variety/"
+metadata/initialization_lobby = "res://scenes/lobby/"
 
 [node name="Music" type="Node3D" parent="."]
 

--- a/main.tscn
+++ b/main.tscn
@@ -24,6 +24,7 @@ glow_enabled = true
 
 [node name="Main" type="Node3D"]
 script = ExtResource("1_r1x4e")
+metadata/initialization_lobby = "res://scenes/lobby/"
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource("Environment_0mmb7")
@@ -85,7 +86,6 @@ transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, -3, 1.
 
 [node name="Levels" type="Node3D" parent="."]
 metadata/initialization_level = "res://levels/shape_variety/"
-metadata/initialization_lobby = "res://scenes/lobby/"
 
 [node name="Music" type="Node3D" parent="."]
 

--- a/src/game/JumpvalleyPlayer.cs
+++ b/src/game/JumpvalleyPlayer.cs
@@ -22,8 +22,10 @@ namespace JumpvalleyGame
     /// </summary>
     public partial class JumpvalleyPlayer : Player, IDisposable
     {
-        private ConsoleLogger logger;
+        private static readonly string INITIALIZATION_LEVEL_META_NAME = "initialization_level";
+        private static readonly string INITIALIZATION_LOBBY_META_NAME = "initialization_lobby";
 
+        private ConsoleLogger logger;
         private JumpvalleySettings settings;
 
         public JumpvalleyPlayer(SceneTree tree, Node rootNode) : base(tree, rootNode)
@@ -173,25 +175,31 @@ namespace JumpvalleyGame
             UserLevelRunner levelRunner = new UserLevelRunner(this, new LevelTimer(PrimaryGui.GetNode("LevelTimer")));
             RootNode.AddChild(levelRunner);
 
-            // Load the lobby
-            LevelPackage lobby = new LevelPackage("res://scenes/lobby", levelRunner);
-            levelRunner.Lobby = lobby;
-            Disposables.Add(lobby);
-            lobby.LoadRootNode();
-            lobby.CreateLevelInstance();
-            lobby.StartLevel();
-            RootNode.AddChild(lobby.RootNode);
-            lobby.LevelInstance.SendPlayerToCurrentCheckpoint();
+            // Load the initialization lobby (the lobby we want to load in when the game starts)
+            if (RootNode.HasMeta(INITIALIZATION_LOBBY_META_NAME))
+            {
+                string lobbyPath = RootNode.GetMeta(INITIALIZATION_LOBBY_META_NAME).As<string>();
+                if (!string.IsNullOrEmpty(lobbyPath))
+                {
+                    LevelPackage lobby = new LevelPackage(lobbyPath, levelRunner);
+                    levelRunner.Lobby = lobby;
+                    Disposables.Add(lobby);
+                    lobby.LoadRootNode();
+                    lobby.CreateLevelInstance();
+                    lobby.StartLevel();
+                    RootNode.AddChild(lobby.RootNode);
+                    lobby.LevelInstance.SendPlayerToCurrentCheckpoint();
+                }
+            }
 
             // Load the initialization level (the level we want to load in when the game starts)
             string levelsNodeName = "Levels";
-            string initializationLevelMetadataName = "initialization_level";
             Node levelsNode = RootNode.GetNode(levelsNodeName);
             if (levelsNode != null)
             {
-                if (levelsNode.HasMeta(initializationLevelMetadataName))
+                if (levelsNode.HasMeta(INITIALIZATION_LEVEL_META_NAME))
                 {
-                    string levelPath = levelsNode.GetMeta(initializationLevelMetadataName).As<string>();
+                    string levelPath = levelsNode.GetMeta(INITIALIZATION_LEVEL_META_NAME).As<string>();
 
                     if (!string.IsNullOrEmpty(levelPath))
                     {


### PR DESCRIPTION
This new metadata entry, specified in the root node of the main scene (`main.tscn`), can be used to specify the lobby that should load when the game starts up.