### PR TITLE
Implement songs array for music list nodes

### DIFF
--- a/levels/demo_platformer/level.tscn
+++ b/levels/demo_platformer/level.tscn
@@ -287,7 +287,7 @@ skeleton = NodePath("../../../../..")
 [node name="MusicZone1" type="Node3D" parent="Music/MusicZones"]
 
 [node name="Music" type="Node" parent="Music/MusicZones/MusicZone1"]
-metadata/song1 = "res://addons/music/1139009_The-Trail/"
+metadata/songs = ["res://addons/music/1139009_The-Trail/"]
 
 [node name="ZoneParts" type="Node3D" parent="Music/MusicZones/MusicZone1"]
 

--- a/levels/shape_variety/level.tscn
+++ b/levels/shape_variety/level.tscn
@@ -335,7 +335,7 @@ mesh = SubResource("BoxMesh_p3ea6")
 [node name="MusicZone1" type="Node3D" parent="Music/MusicZones"]
 
 [node name="Music" type="Node" parent="Music/MusicZones/MusicZone1"]
-metadata/song1 = "res://addons/music/1226171_The-Way-It-Is/"
+metadata/songs = ["res://addons/music/1226171_The-Way-It-Is/"]
 
 [node name="ZoneParts" type="Node3D" parent="Music/MusicZones/MusicZone1"]
 

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -576,6 +576,6 @@ mesh = SubResource("CylinderMesh_h17i4")
 [node name="PrimaryMusic" type="Node" parent="Music"]
 
 [node name="Music" type="Node" parent="Music/PrimaryMusic"]
-metadata/song1 = "res://addons/music/1215548_Shivers/"
+metadata/songs = ["res://addons/music/1215548_Shivers/"]
 
 [node name="MusicZones" type="Node3D" parent="Music"]

--- a/src/core/Music/MusicGroup.cs
+++ b/src/core/Music/MusicGroup.cs
@@ -18,7 +18,7 @@ namespace Jumpvalley.Music
     /// <br/><br/>
     /// <b>Incremental songN metadata entries</b>
     /// <br/>
-    /// Multiple metadata entries are specified in this format:
+    /// This method is used when no songs array is present in the metadata. Multiple metadata entries should be specified in this format:
     /// <br/>
     /// Entry name: <c>songN</c> where N represents the numerical index of the song package directory starting from 1. Songs are played in numerical order.
     /// <br/>

--- a/src/core/Music/MusicGroup.cs
+++ b/src/core/Music/MusicGroup.cs
@@ -1,9 +1,6 @@
 ﻿using Godot;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Jumpvalley.Music
 {
@@ -11,19 +8,33 @@ namespace Jumpvalley.Music
     /// Handles a <see cref="Playlist"/> that's in the form of nodes in a scene tree.
     /// <br/>
     /// Each MusicGroup node must have a node as a direct child named "Music" that lists the directory (folder) paths of songs in its metadata.
+    /// <br/><br/>
+    /// There are two ways to specify songs that should be played:
+    /// <br/><br/>
+    /// <b>songs array in metadata</b>
     /// <br/>
-    /// The metadata has to list each song's folder in this format:
+    /// The metadata (as mentioned above) has an array named `songs` that specifies the songs to play.
+    /// The array's C# type should be <see cref="Godot.Collections.Array"/>.
+    /// <br/><br/>
+    /// <b>Incremental songN metadata entries</b>
+    /// <br/>
+    /// Multiple metadata entries are specified in this format:
     /// <br/>
     /// Entry name: <c>songN</c> where N represents the numerical index of the song package directory starting from 1. Songs are played in numerical order.
     /// <br/>
     /// Entry value: The absolute path to the song's directory. (The value's type must be string.)
     /// </summary>
-    public partial class MusicGroup: Playlist, IDisposable
+    public partial class MusicGroup : Playlist, IDisposable
     {
         /// <summary>
         /// The prefix of the song metadata entry name within <see cref="MusicListNode"/>
         /// </summary>
         public static readonly string SONG_METADATA_ENTRY_PREFIX = "song";
+
+        /// <summary>
+        /// Name of the metadata entry storing the songs array
+        /// </summary>
+        public static readonly string SONGS_META_NAME = "songs";
 
         /// <summary>
         /// The name of the node that contains the list of songs as metadata
@@ -55,33 +66,56 @@ namespace Jumpvalley.Music
             {
                 throw new ArgumentNullException("Specified " + nameof(node) + " is null. Please specify an actual node.");
             }
-            
+
             ActualNode = node;
             MusicListNode = node.GetNode(MUSIC_LIST_NODE_NAME);
-            
+
             node.AddChild(this);
 
-            // Add the song packages
-            int packageIndex = 1;
-            while (true)
+            // Add songs from package paths specified in songs array
+            if (MusicListNode.HasMeta(SONGS_META_NAME))
             {
-                string metaName = SONG_METADATA_ENTRY_PREFIX + packageIndex;
+                Godot.Collections.Array songs = MusicListNode.GetMeta(SONGS_META_NAME).As<Godot.Collections.Array>();
 
-                if (!MusicListNode.HasMeta(metaName))
+                if (songs != null)
                 {
-                    break;
+                    foreach (Variant song in songs)
+                    {
+                        if (song.VariantType == Variant.Type.String)
+                        {
+                            string packagePath = song.As<string>();
+                            if (!string.IsNullOrEmpty(packagePath))
+                            {
+                                SongPackages.Add(new SongPackage(packagePath));
+                            }
+                        }
+                    }
                 }
-
-                Variant meta = MusicListNode.GetMeta(metaName);
-                string songDir = meta.As<string>();
-
-                if (string.IsNullOrEmpty(songDir))
+            }
+            else
+            {
+                // Add the song packages (legacy behavior)
+                int packageIndex = 1;
+                while (true)
                 {
-                    break;
-                }
+                    string metaName = SONG_METADATA_ENTRY_PREFIX + packageIndex;
 
-                SongPackages.Add(new SongPackage(songDir));
-                packageIndex++;
+                    if (!MusicListNode.HasMeta(metaName))
+                    {
+                        break;
+                    }
+
+                    Variant meta = MusicListNode.GetMeta(metaName);
+                    string songDir = meta.As<string>();
+
+                    if (string.IsNullOrEmpty(songDir))
+                    {
+                        break;
+                    }
+
+                    SongPackages.Add(new SongPackage(songDir));
+                    packageIndex++;
+                }
             }
 
             // Add the corresponding songs to the playlist


### PR DESCRIPTION
This allows songs to be specified in the music list node in an array named `songs` within the node's metadata.