### PR TITLE
Implement level primary playlist

### DIFF
--- a/levels/shape_variety/level.tscn
+++ b/levels/shape_variety/level.tscn
@@ -345,11 +345,6 @@ visible = false
 mesh = SubResource("BoxMesh_bi26x")
 skeleton = NodePath("../..")
 
-[node name="PrimaryMusic" type="Node" parent="Music"]
-
-[node name="Music" type="Node" parent="Music/PrimaryMusic"]
-metadata/song1 = ""
-
 [node name="StaticObjects" type="Node3D" parent="."]
 
 [node name="Base" type="StaticBody3D" parent="StaticObjects"]

--- a/main.tscn
+++ b/main.tscn
@@ -92,6 +92,5 @@ metadata/initialization_level = "res://levels/shape_variety/"
 [node name="PrimaryMusic" type="Node" parent="Music"]
 
 [node name="Music" type="Node" parent="Music/PrimaryMusic"]
-metadata/song1 = "res://addons/music/1215548_Shivers/"
 
 [node name="MusicZones" type="Node3D" parent="Music"]

--- a/src/core/Levels/Level.cs
+++ b/src/core/Levels/Level.cs
@@ -85,7 +85,7 @@ namespace Jumpvalley.Levels
         /// <summary>
         /// The level's primary music playlist
         /// </summary>
-        public MusicGroup PrimaryPlaylist;
+        public MusicGroup PrimaryPlaylist { get; private set; }
 
         /// <summary>
         /// The node containing the level's static objects
@@ -168,8 +168,12 @@ namespace Jumpvalley.Levels
                     }
                 }
 
-                Node primaryMusicNode = Music.GetNode("PrimaryMusic");
-                if (primaryMusicNode != null)
+                Node primaryMusicNode = Music.GetNodeOrNull("PrimaryMusic");
+                if (primaryMusicNode == null)
+                {
+                    PrimaryPlaylist = null;
+                }
+                else
                 {
                     PrimaryPlaylist = new MusicGroup(primaryMusicNode);
                 }

--- a/src/core/Levels/Level.cs
+++ b/src/core/Levels/Level.cs
@@ -389,6 +389,11 @@ namespace Jumpvalley.Levels
                     i.Dispose();
                 }
             }
+            foreach (MusicZone zone in MusicZones)
+            {
+                zone.Dispose();
+            }
+            PrimaryPlaylist?.Dispose();
 
             base.Dispose();
         }

--- a/src/core/Levels/Level.cs
+++ b/src/core/Levels/Level.cs
@@ -83,6 +83,11 @@ namespace Jumpvalley.Levels
         public List<MusicZone> MusicZones { get; private set; }
 
         /// <summary>
+        /// The level's primary music playlist
+        /// </summary>
+        public MusicGroup PrimaryPlaylist;
+
+        /// <summary>
         /// The node containing the level's static objects
         /// </summary>
         public Node StaticObjects { get; private set; }
@@ -161,6 +166,12 @@ namespace Jumpvalley.Levels
                     {
                         MusicZones.Add(new MusicZone(zoneNode));
                     }
+                }
+
+                Node primaryMusicNode = Music.GetNode("PrimaryMusic");
+                if (primaryMusicNode != null)
+                {
+                    PrimaryPlaylist = new MusicGroup(primaryMusicNode);
                 }
             }
 

--- a/src/game/JumpvalleyPlayer.cs
+++ b/src/game/JumpvalleyPlayer.cs
@@ -188,7 +188,15 @@ namespace JumpvalleyGame
                     lobby.CreateLevelInstance();
                     lobby.StartLevel();
                     RootNode.AddChild(lobby.RootNode);
-                    lobby.LevelInstance.SendPlayerToCurrentCheckpoint();
+
+                    Level lobbyLevel = lobby.LevelInstance;
+                    lobbyLevel.SendPlayerToCurrentCheckpoint();
+
+                    MusicGroup lobbyPrimaryPlaylist = lobbyLevel.PrimaryPlaylist;
+                    if (lobbyPrimaryPlaylist != null)
+                    {
+                        CurrentMusicPlayer.PrimaryPlaylist = lobbyPrimaryPlaylist;
+                    }
                 }
             }
 
@@ -210,7 +218,15 @@ namespace JumpvalleyGame
                         levelPackage.CreateLevelInstance();
                         levelPackage.StartLevel();
                         levelsNode.AddChild(levelPackage.RootNode);
-                        levelPackage.LevelInstance.SendPlayerToCurrentCheckpoint();
+
+                        Level levelInstance = levelPackage.LevelInstance;
+                        levelInstance.SendPlayerToCurrentCheckpoint();
+
+                        MusicGroup levelPrimaryPlaylist = levelInstance.PrimaryPlaylist;
+                        if (levelPrimaryPlaylist != null)
+                        {
+                            CurrentMusicPlayer.PrimaryPlaylist = levelPrimaryPlaylist;
+                        }
 
                         LevelInfo levelInfo = levelPackage.Info;
                         Difficulty difficulty = levelInfo.LevelDifficulty;

--- a/src/game/JumpvalleyPlayer.cs
+++ b/src/game/JumpvalleyPlayer.cs
@@ -195,6 +195,7 @@ namespace JumpvalleyGame
                     MusicGroup lobbyPrimaryPlaylist = lobbyLevel.PrimaryPlaylist;
                     if (lobbyPrimaryPlaylist != null)
                     {
+                        CurrentMusicPlayer.AddPlaylist(lobbyPrimaryPlaylist);
                         CurrentMusicPlayer.PrimaryPlaylist = lobbyPrimaryPlaylist;
                     }
                 }
@@ -225,6 +226,7 @@ namespace JumpvalleyGame
                         MusicGroup levelPrimaryPlaylist = levelInstance.PrimaryPlaylist;
                         if (levelPrimaryPlaylist != null)
                         {
+                            CurrentMusicPlayer.AddPlaylist(levelPrimaryPlaylist);
                             CurrentMusicPlayer.PrimaryPlaylist = levelPrimaryPlaylist;
                         }
 


### PR DESCRIPTION
This allows levels to specify a primary playlist to use, instead of only using the primary playlist specified in `main.tscn`.