### PR TITLE
Rename data directory used by release build of Jumpvalley

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -19,7 +19,7 @@ boot_splash/bg_color=Color(0, 0, 0, 1)
 boot_splash/show_image=false
 config/icon="res://icons/app_icon_desktop_256px.png"
 config/use_custom_user_dir.jumpvalley_custom_user_dir=true
-config/custom_user_dir_name.jumpvalley_custom_user_dir="Jumpvalley"
+config/custom_user_dir_name.jumpvalley_custom_user_dir="jumpvalley_data"
 
 [display]
 


### PR DESCRIPTION
This PR renames the data directory used by the release build of Jumpvalley from "Jumpvalley" to "jumpvalley_data"