### PR TITLE
Replace occurrences of Juke's Towers of Hell with Eternal Towers of Hell

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ A list of such assets that are used in this project can be found [here](https://
 Jumpvalley was inspired by several fun platformers that you should check out, including:
 
 - [Celeste](https://www.celestegame.com/)
+- [Eternal Towers of Hell](https://www.roblox.com/games/8562822414/Eternal-Towers-of-Hell)
 - [Flood Escape 2](https://www.roblox.com/games/738339342/Flood-Escape-2)
-- [Juke's Towers of Hell](https://www.roblox.com/games/8562822414/Jukes-Towers-of-Hell)
 
 ## Licensing
 

--- a/notes.md
+++ b/notes.md
@@ -44,4 +44,4 @@ Use the standard ```Console.WriteLine()```, and export the project to an exe wit
 - Player's (their character's) gravity (as in gravitational acceleration) seems to be the same as a box with a mass of 0.01kg as of Jumpvalley v0.3.0
     - Changing physics refresh rate from 60 hz to 120 hz and vice versa does not seem to make a difference in the gravitational acceleration of the box or the player's character. Increasing the physics refresh rate from 60 hz or 120 hz to 240 hz does not make a difference either.
     - However, increasing the physics refresh rate from 60 hz to 120 hz has made the box easier to push. Increasing the refresh rate from 120 hz to 240 hz seems to have made physics in Jumpvalley more stable as well.
-- In Juke's Towers of Hell, the physics refresh rate is 240 hz.
+- In Eternal Towers of Hell, the physics refresh rate is 240 hz.

--- a/src/app/JumpvalleyPlayer.cs
+++ b/src/app/JumpvalleyPlayer.cs
@@ -112,7 +112,7 @@ namespace JumpvalleyApp
             Disposables.Add(characterBoundingBox);
 
             // Set up character movement
-            // Some values here are based on Juke's Towers of Hell physics (or somewhere close), except we're working with meters.
+            // Some values here are based on Eternal Towers of Hell physics (or somewhere close), except we're working with meters.
             // In-app gravity can be changed at runtime, so we need to account for that. See:
             // https://docs.godotengine.org/en/stable/classes/class_projectsettings.html#class-projectsettings-property-physics-3d-default-gravity
             // for more details.
@@ -147,7 +147,7 @@ namespace JumpvalleyApp
             RootNode.AddChild(Mover);
             RootNode.AddChild(Camera);
 
-            // Input with higher accuracy and less lag is preferred in Juke's Towers of Hell fangames,
+            // Input with higher accuracy and less lag is preferred in Eternal Towers of Hell fangames,
             // since very small differences in input can have a large impact on gameplay.
             // This is why it's important to make the input refresh rate independent from display refresh rate.
             Input.UseAccumulatedInput = false;

--- a/src/core/Music/MusicZonePlayer.cs
+++ b/src/core/Music/MusicZonePlayer.cs
@@ -7,7 +7,7 @@ namespace Jumpvalley.Music
     /// <summary>
     /// MusicPlayer that handles the playback of <see cref="Playlist"/>s with music zones in mind.
     /// <br/>
-    /// Music zone logic is handled like how it is in Juke's Towers of Hell.
+    /// Music zone logic is handled like how it is in Eternal Towers of Hell.
     /// This means that whenever a player enters a music zone, the zone's playlist gets played.
     /// <br/>
     /// In order for music to play when the player is outside a music zone, a primary playlist must be set.


### PR DESCRIPTION
Juke's Towers of Hell was recently renamed to Eternal Towers of Hell (found [here](https://www.roblox.com/games/8562822414/Eternal-Towers-of-Hell)). This PR reflects that change by replacing occurrences of "Juke's Towers of Hell" in the source code to "Eternal Towers of Hell".