### PR TITLE
Change namespaces of core API classes

### DIFF
--- a/src/app/Gui/BgPanelAnimatedNodeGroup.cs
+++ b/src/app/Gui/BgPanelAnimatedNodeGroup.cs
@@ -1,6 +1,6 @@
 using System;
-using Jumpvalley.Animation;
-using Jumpvalley.Gui;
+using UTheCat.Jumpvalley.Core.Animation;
+using UTheCat.Jumpvalley.Core.Gui;
 
 namespace JumpvalleyApp.Gui
 {

--- a/src/app/Gui/BottomBar.cs
+++ b/src/app/Gui/BottomBar.cs
@@ -1,7 +1,7 @@
 ﻿using Godot;
-using Jumpvalley.Animation;
-using Jumpvalley.Music;
-using Jumpvalley.Tweening;
+using UTheCat.Jumpvalley.Core.Animation;
+using UTheCat.Jumpvalley.Core.Music;
+using UTheCat.Jumpvalley.Core.Tweening;
 using System;
 
 namespace JumpvalleyApp.Gui

--- a/src/app/Gui/FastTurnIndicator.cs
+++ b/src/app/Gui/FastTurnIndicator.cs
@@ -1,7 +1,7 @@
 using Godot;
 using System;
 
-using Jumpvalley.Players.Movement;
+using UTheCat.Jumpvalley.Core.Players.Movement;
 
 namespace JumpvalleyApp.Gui
 {

--- a/src/app/Gui/FramerateCounter.cs
+++ b/src/app/Gui/FramerateCounter.cs
@@ -1,7 +1,7 @@
 using System;
 using Godot;
-using Jumpvalley.Animation;
-using Jumpvalley.Tweening;
+using UTheCat.Jumpvalley.Core.Animation;
+using UTheCat.Jumpvalley.Core.Tweening;
 
 namespace JumpvalleyApp.Gui
 {

--- a/src/app/Gui/LevelMenu.cs
+++ b/src/app/Gui/LevelMenu.cs
@@ -1,8 +1,8 @@
 ﻿using Godot;
 using System;
 
-using Jumpvalley.Animation;
-using Jumpvalley.Tweening;
+using UTheCat.Jumpvalley.Core.Animation;
+using UTheCat.Jumpvalley.Core.Tweening;
 
 namespace JumpvalleyApp.Gui
 {

--- a/src/app/Gui/LevelTimer.cs
+++ b/src/app/Gui/LevelTimer.cs
@@ -1,5 +1,5 @@
 ﻿using Godot;
-using Jumpvalley.Timing;
+using UTheCat.Jumpvalley.Core.Timing;
 
 namespace JumpvalleyApp.Gui
 {

--- a/src/app/Gui/MusicPanel.cs
+++ b/src/app/Gui/MusicPanel.cs
@@ -1,6 +1,6 @@
 using System;
 using Godot;
-using Jumpvalley.Music;
+using UTheCat.Jumpvalley.Core.Music;
 
 namespace JumpvalleyApp.Gui
 {

--- a/src/app/Gui/SettingsMenu.cs
+++ b/src/app/Gui/SettingsMenu.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using Godot;
-using Jumpvalley.Animation;
-using Jumpvalley.Tweening;
+using UTheCat.Jumpvalley.Core.Animation;
+using UTheCat.Jumpvalley.Core.Tweening;
 
 using JumpvalleyApp.Gui.Settings;
 using JumpvalleyApp.Settings;

--- a/src/app/JumpvalleyPlayer.cs
+++ b/src/app/JumpvalleyPlayer.cs
@@ -3,13 +3,13 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json.Nodes;
 
-using Jumpvalley.Gui;
-using Jumpvalley.Levels;
-using Jumpvalley.Levels.Interactives.Mechanics;
-using Jumpvalley.Logging;
-using Jumpvalley.Music;
-using Jumpvalley.Players;
-using Jumpvalley.Tweening;
+using UTheCat.Jumpvalley.Core.Gui;
+using UTheCat.Jumpvalley.Core.Levels;
+using UTheCat.Jumpvalley.Core.Levels.Interactives.Mechanics;
+using UTheCat.Jumpvalley.Core.Logging;
+using UTheCat.Jumpvalley.Core.Music;
+using UTheCat.Jumpvalley.Core.Players;
+using UTheCat.Jumpvalley.Core.Tweening;
 
 using JumpvalleyApp.Display;
 using JumpvalleyApp.Gui;

--- a/src/app/Levels/UserLevelRunner.cs
+++ b/src/app/Levels/UserLevelRunner.cs
@@ -1,7 +1,7 @@
 using System;
 
-using Jumpvalley.Levels;
-using Jumpvalley.Players;
+using UTheCat.Jumpvalley.Core.Levels;
+using UTheCat.Jumpvalley.Core.Players;
 
 using JumpvalleyApp.Gui;
 

--- a/src/app/Players/Camera/UserInputCamera.cs
+++ b/src/app/Players/Camera/UserInputCamera.cs
@@ -1,7 +1,7 @@
 ﻿using Godot;
 using System;
 
-using Jumpvalley.Players.Camera;
+using UTheCat.Jumpvalley.Core.Players.Camera;
 
 namespace JumpvalleyApp.Players.Camera
 {

--- a/src/app/Players/Movement/FastTurnControl.cs
+++ b/src/app/Players/Movement/FastTurnControl.cs
@@ -1,8 +1,8 @@
 ﻿using Godot;
 using System;
 
-using Jumpvalley.Players.Camera;
-using Jumpvalley.Players.Movement;
+using UTheCat.Jumpvalley.Core.Players.Camera;
+using UTheCat.Jumpvalley.Core.Players.Movement;
 
 namespace JumpvalleyApp.Players.Movement
 {

--- a/src/app/Players/Movement/KeyboardMover.cs
+++ b/src/app/Players/Movement/KeyboardMover.cs
@@ -1,6 +1,6 @@
 ﻿using Godot;
 
-using Jumpvalley.Players.Movement;
+using UTheCat.Jumpvalley.Core.Players.Movement;
 
 namespace JumpvalleyApp.Players.Movement
 {

--- a/src/app/Settings/SettingsFile.cs
+++ b/src/app/Settings/SettingsFile.cs
@@ -2,7 +2,7 @@ using System;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Godot;
-using Jumpvalley.Logging;
+using UTheCat.Jumpvalley.Core.Logging;
 
 namespace JumpvalleyApp.Settings
 {

--- a/src/app/Testing/AccelerationTest.cs
+++ b/src/app/Testing/AccelerationTest.cs
@@ -1,5 +1,5 @@
 using Godot;
-using Jumpvalley.Players.Movement;
+using UTheCat.Jumpvalley.Core.Players.Movement;
 
 namespace JumpvalleyApp.Testing
 {

--- a/src/app/Testing/InfoFileTest.cs
+++ b/src/app/Testing/InfoFileTest.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Jumpvalley.IO;
+using UTheCat.Jumpvalley.Core.IO;
 
 namespace JumpvalleyApp.Testing
 {

--- a/src/app/Testing/LevelLoadingTest.cs
+++ b/src/app/Testing/LevelLoadingTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Godot;
-using Jumpvalley.Levels;
-using Jumpvalley.Players;
+using UTheCat.Jumpvalley.Core.Levels;
+using UTheCat.Jumpvalley.Core.Players;
 
 using JumpvalleyApp.Gui;
 

--- a/src/app/Testing/MethodTweenTest.cs
+++ b/src/app/Testing/MethodTweenTest.cs
@@ -1,7 +1,7 @@
 using Godot;
 using System;
 
-using Jumpvalley.Tweening;
+using UTheCat.Jumpvalley.Core.Tweening;
 
 namespace JumpvalleyApp.Testing
 {

--- a/src/app/Testing/RaycastSweepTest.cs
+++ b/src/app/Testing/RaycastSweepTest.cs
@@ -1,7 +1,7 @@
 ﻿using Godot;
 using System;
 
-using Jumpvalley.Raycasting;
+using UTheCat.Jumpvalley.Core.Raycasting;
 
 namespace JumpvalleyApp.Testing
 {

--- a/src/app/Testing/SongPackageTest.cs
+++ b/src/app/Testing/SongPackageTest.cs
@@ -1,7 +1,7 @@
 ﻿using Godot;
 using System;
 
-using Jumpvalley.Music;
+using UTheCat.Jumpvalley.Core.Music;
 
 namespace JumpvalleyApp.Testing
 {

--- a/src/app/Testing/TeleporterTest.cs
+++ b/src/app/Testing/TeleporterTest.cs
@@ -1,9 +1,9 @@
 using System;
 using Godot;
-using Jumpvalley.Levels.Interactives;
-using Jumpvalley.Levels.Interactives.Mechanics;
-using Jumpvalley.Levels.Interactives.Mechanics.Teleporters;
-using Jumpvalley.Timing;
+using UTheCat.Jumpvalley.Core.Levels.Interactives;
+using UTheCat.Jumpvalley.Core.Levels.Interactives.Mechanics;
+using UTheCat.Jumpvalley.Core.Levels.Interactives.Mechanics.Teleporters;
+using UTheCat.Jumpvalley.Core.Timing;
 
 namespace JumpvalleyApp.Testing
 {

--- a/src/core/Animation/AnimatedNode.cs
+++ b/src/core/Animation/AnimatedNode.cs
@@ -1,7 +1,7 @@
 ﻿using Godot;
 using System;
 
-namespace Jumpvalley.Animation
+namespace UTheCat.Jumpvalley.Core.Animation
 {
     /// <summary>
     /// This class provides some components to bind to a Godot node,

--- a/src/core/Animation/AnimatedNodeGroup.cs
+++ b/src/core/Animation/AnimatedNodeGroup.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Jumpvalley.Animation
+namespace UTheCat.Jumpvalley.Core.Animation
 {
     /// <summary>
     /// Class that groups multiple <see cref="AnimatedNode"/>s together so that they can communicate with each other.

--- a/src/core/Audio/AudioStreamReader.cs
+++ b/src/core/Audio/AudioStreamReader.cs
@@ -2,7 +2,7 @@
 using System;
 using System.IO;
 
-namespace Jumpvalley.Audio
+namespace UTheCat.Jumpvalley.Core.Audio
 {
     /// <summary>
     /// Loads a file that's either imported as a resource (at one point or another) or somewhere on the filesystem.

--- a/src/core/Gui/BackgroundPanel.cs
+++ b/src/core/Gui/BackgroundPanel.cs
@@ -1,9 +1,9 @@
 using Godot;
 
-using Jumpvalley.Animation;
-using Jumpvalley.Tweening;
+using UTheCat.Jumpvalley.Core.Animation;
+using UTheCat.Jumpvalley.Core.Tweening;
 
-namespace Jumpvalley.Gui
+namespace UTheCat.Jumpvalley.Core.Gui
 {
     /// <summary>
     /// Handler for the BackgroundPanel,

--- a/src/core/IO/InfoFile.cs
+++ b/src/core/IO/InfoFile.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Jumpvalley.IO
+namespace UTheCat.Jumpvalley.Core.IO
 {
     /// <summary>
     /// Reads an Info file, a blob of text that's primarily for defining metadata for a specific object, such as an audio file or a level.

--- a/src/core/IO/JsonInfoFile.cs
+++ b/src/core/IO/JsonInfoFile.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Nodes;
 
-namespace Jumpvalley.IO
+namespace UTheCat.Jumpvalley.Core.IO
 {
     /// <summary>
     /// Class intended to help with using the data from info files written in JavaScript Object Notation (JSON).

--- a/src/core/IO/PathUtil.cs
+++ b/src/core/IO/PathUtil.cs
@@ -1,4 +1,4 @@
-namespace Jumpvalley.IO
+namespace UTheCat.Jumpvalley.Core.IO
 {
     /// <summary>
     /// Provides some values and methods for performing operations related to file paths.

--- a/src/core/Levels/Difficulty.cs
+++ b/src/core/Levels/Difficulty.cs
@@ -1,6 +1,6 @@
 ﻿using Godot;
 
-namespace Jumpvalley.Levels
+namespace UTheCat.Jumpvalley.Core.Levels
 {
     /// <summary>
     /// Represents a difficulty, a set of values that judge how difficult a level is.

--- a/src/core/Levels/DifficultyPresets.cs
+++ b/src/core/Levels/DifficultyPresets.cs
@@ -1,7 +1,7 @@
 ﻿using Godot;
 using System.Collections.Generic;
 
-namespace Jumpvalley.Levels
+namespace UTheCat.Jumpvalley.Core.Levels
 {
     /// <summary>
     /// This class contains some difficulty sets that can be used to label the difficulty of a level.

--- a/src/core/Levels/DifficultySet.cs
+++ b/src/core/Levels/DifficultySet.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Jumpvalley.Levels
+namespace UTheCat.Jumpvalley.Core.Levels
 {
     /// <summary>
     /// Class that groups multiple difficulties together.

--- a/src/core/Levels/DirectoryLevelRunner.cs
+++ b/src/core/Levels/DirectoryLevelRunner.cs
@@ -1,6 +1,6 @@
-using Jumpvalley.Players;
+using UTheCat.Jumpvalley.Core.Players;
 
-namespace Jumpvalley.Levels
+namespace UTheCat.Jumpvalley.Core.Levels
 {
     /// <summary>
     /// Subclass of <see cref="LevelRunner"/> that handles running levels located within a directory. 

--- a/src/core/Levels/Interactives/Interactive.cs
+++ b/src/core/Levels/Interactives/Interactive.cs
@@ -1,12 +1,12 @@
 ﻿using Godot;
 using System;
 
-using Jumpvalley.Timing;
+using UTheCat.Jumpvalley.Core.Timing;
 
-namespace Jumpvalley.Levels.Interactives
+namespace UTheCat.Jumpvalley.Core.Levels.Interactives
 {
     /// <summary>
-    /// The base class for all Interactive types in Jumpvalley.
+    /// The base class for all Interactive types in UTheCat.Jumpvalley.Core.
     /// </summary>
     public partial class Interactive : Node, IDisposable
     {

--- a/src/core/Levels/Interactives/InteractiveNode.cs
+++ b/src/core/Levels/Interactives/InteractiveNode.cs
@@ -1,9 +1,9 @@
 ﻿using Godot;
 using System;
 
-using Jumpvalley.Timing;
+using UTheCat.Jumpvalley.Core.Timing;
 
-namespace Jumpvalley.Levels.Interactives
+namespace UTheCat.Jumpvalley.Core.Levels.Interactives
 {
     /// <summary>
     /// A subclass of <see cref="Interactive"/> that operates over a Godot node.

--- a/src/core/Levels/Interactives/InteractiveToolkit.cs
+++ b/src/core/Levels/Interactives/InteractiveToolkit.cs
@@ -1,6 +1,6 @@
 ﻿using Godot;
 
-namespace Jumpvalley.Levels.Interactives
+namespace UTheCat.Jumpvalley.Core.Levels.Interactives
 {
     /// <summary>
     /// Provides some variables and methods that may assist with the development of interactives.

--- a/src/core/Levels/Interactives/Mechanics/CheckpointSet.cs
+++ b/src/core/Levels/Interactives/Mechanics/CheckpointSet.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using Godot;
-using Jumpvalley.Levels.Interactives.Mechanics.Teleporters;
-using Jumpvalley.Timing;
+using UTheCat.Jumpvalley.Core.Levels.Interactives.Mechanics.Teleporters;
+using UTheCat.Jumpvalley.Core.Timing;
 
-namespace Jumpvalley.Levels.Interactives.Mechanics
+namespace UTheCat.Jumpvalley.Core.Levels.Interactives.Mechanics
 {
     /// <summary>
     /// Interactive that handles checkpoints for a level.

--- a/src/core/Levels/Interactives/Mechanics/OverallBoundingBoxObject.cs
+++ b/src/core/Levels/Interactives/Mechanics/OverallBoundingBoxObject.cs
@@ -1,8 +1,8 @@
 using Godot;
 
-using Jumpvalley.Timing;
+using UTheCat.Jumpvalley.Core.Timing;
 
-namespace Jumpvalley.Levels.Interactives.Mechanics
+namespace UTheCat.Jumpvalley.Core.Levels.Interactives.Mechanics
 {
     /// <summary>
     /// Interactive that calculates its root node's

--- a/src/core/Levels/Interactives/Mechanics/Spinner.cs
+++ b/src/core/Levels/Interactives/Mechanics/Spinner.cs
@@ -1,9 +1,9 @@
 ﻿using Godot;
 using System;
 
-using Jumpvalley.Timing;
+using UTheCat.Jumpvalley.Core.Timing;
 
-namespace Jumpvalley.Levels.Interactives.Mechanics
+namespace UTheCat.Jumpvalley.Core.Levels.Interactives.Mechanics
 {
     /// <summary>
     /// A basic spinner. A spinner is a rotating platform.

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/StartEndTeleporter.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
 using Godot;
 using Godot.Collections;
-using Jumpvalley.Players;
-using Jumpvalley.Timing;
+using UTheCat.Jumpvalley.Core.Players;
+using UTheCat.Jumpvalley.Core.Timing;
 
-namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
+namespace UTheCat.Jumpvalley.Core.Levels.Interactives.Mechanics.Teleporters
 {
     /// <summary>
     /// Type of teleporter that teleports a node to <see cref="Teleporter.Destination"/>

--- a/src/core/Levels/Interactives/Mechanics/Teleporters/Teleporter.cs
+++ b/src/core/Levels/Interactives/Mechanics/Teleporters/Teleporter.cs
@@ -1,7 +1,7 @@
 using Godot;
-using Jumpvalley.Timing;
+using UTheCat.Jumpvalley.Core.Timing;
 
-namespace Jumpvalley.Levels.Interactives.Mechanics.Teleporters
+namespace UTheCat.Jumpvalley.Core.Levels.Interactives.Mechanics.Teleporters
 {
     /// <summary>
     /// Interactive that sends a Node3D to a defined destination.

--- a/src/core/Levels/Interactives/NodeMetadataChangedArgs.cs
+++ b/src/core/Levels/Interactives/NodeMetadataChangedArgs.cs
@@ -1,6 +1,6 @@
 ﻿using Godot;
 
-namespace Jumpvalley.Levels.Interactives
+namespace UTheCat.Jumpvalley.Core.Levels.Interactives
 {
     /// <summary>
     /// Event arguments for <see cref="InteractiveNode.NodeMetadataChanged"/>

--- a/src/core/Levels/Level.cs
+++ b/src/core/Levels/Level.cs
@@ -2,17 +2,17 @@
 using System;
 using System.Collections.Generic;
 
-using Jumpvalley.Players;
-using Jumpvalley.Music;
-using Jumpvalley.Levels.Interactives;
-using Jumpvalley.Levels.Interactives.Mechanics;
-using Jumpvalley.Levels.Interactives.Mechanics.Teleporters;
-using Jumpvalley.Timing;
+using UTheCat.Jumpvalley.Core.Players;
+using UTheCat.Jumpvalley.Core.Music;
+using UTheCat.Jumpvalley.Core.Levels.Interactives;
+using UTheCat.Jumpvalley.Core.Levels.Interactives.Mechanics;
+using UTheCat.Jumpvalley.Core.Levels.Interactives.Mechanics.Teleporters;
+using UTheCat.Jumpvalley.Core.Timing;
 
-namespace Jumpvalley.Levels
+namespace UTheCat.Jumpvalley.Core.Levels
 {
     /// <summary>
-    /// This class represents a level that's playable in Jumpvalley.
+    /// This class represents a level that's playable in UTheCat.Jumpvalley.Core.
     /// <br/>
     /// Each level contains four primary components: interactives, music, static objects, and start point.
     /// More details can be found on Jumpvalley's wiki article on <see href="https://github.com/UTheCat/jumpvalley/wiki/Level-Layout">Level Layout</see>.

--- a/src/core/Levels/LevelInfo.cs
+++ b/src/core/Levels/LevelInfo.cs
@@ -1,8 +1,8 @@
 using System.Text.Json.Nodes;
 
-using Jumpvalley.IO;
+using UTheCat.Jumpvalley.Core.IO;
 
-namespace Jumpvalley.Levels
+namespace UTheCat.Jumpvalley.Core.Levels
 {
     /// <summary>
     /// Class containing some info about a level

--- a/src/core/Levels/LevelInfoFile.cs
+++ b/src/core/Levels/LevelInfoFile.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 
-namespace Jumpvalley.Levels
+namespace UTheCat.Jumpvalley.Core.Levels
 {
     /// <summary>
     /// Reads an info file for a Jumpvalley level

--- a/src/core/Levels/LevelPackage.cs
+++ b/src/core/Levels/LevelPackage.cs
@@ -2,9 +2,9 @@
 using System;
 using System.Text.Json.Nodes;
 
-using Jumpvalley.IO;
+using UTheCat.Jumpvalley.Core.IO;
 
-namespace Jumpvalley.Levels
+namespace UTheCat.Jumpvalley.Core.Levels
 {
     /// <summary>
     /// This class represents a level package, a filesystem folder that contains the components of a level.

--- a/src/core/Levels/LevelRunner.cs
+++ b/src/core/Levels/LevelRunner.cs
@@ -1,8 +1,8 @@
 ﻿using Godot;
 
-using Jumpvalley.Players;
+using UTheCat.Jumpvalley.Core.Players;
 
-namespace Jumpvalley.Levels
+namespace UTheCat.Jumpvalley.Core.Levels
 {
     /// <summary>
     /// Class responsible for running and stopping levels.

--- a/src/core/Logging/ConsoleLogger.cs
+++ b/src/core/Logging/ConsoleLogger.cs
@@ -1,7 +1,7 @@
 using System;
 using Godot;
 
-namespace Jumpvalley.Logging
+namespace UTheCat.Jumpvalley.Core.Logging
 {
     /// <summary>
     /// Utility class for printing text output to a console or terminal.

--- a/src/core/Music/MusicGroup.cs
+++ b/src/core/Music/MusicGroup.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Jumpvalley.Music
+namespace UTheCat.Jumpvalley.Core.Music
 {
     /// <summary>
     /// Handles a <see cref="Playlist"/> that's in the form of nodes in a scene tree.

--- a/src/core/Music/MusicPlayer.cs
+++ b/src/core/Music/MusicPlayer.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using Godot;
 
-namespace Jumpvalley.Music
+namespace UTheCat.Jumpvalley.Core.Music
 {
     /// <summary>
     /// Plays music that is split into playlists (see <see cref="Playlist"/>)

--- a/src/core/Music/MusicZone.cs
+++ b/src/core/Music/MusicZone.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 
-namespace Jumpvalley.Music
+namespace UTheCat.Jumpvalley.Core.Music
 {
     /// <summary>
     /// Represents a single music zone.

--- a/src/core/Music/MusicZonePlayer.cs
+++ b/src/core/Music/MusicZonePlayer.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Jumpvalley.Music
+namespace UTheCat.Jumpvalley.Core.Music
 {
     /// <summary>
     /// MusicPlayer that handles the playback of <see cref="Playlist"/>s with music zones in mind.

--- a/src/core/Music/Playlist.cs
+++ b/src/core/Music/Playlist.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using Godot;
 
-using Jumpvalley.Tweening;
+using UTheCat.Jumpvalley.Core.Tweening;
 
-namespace Jumpvalley.Music
+namespace UTheCat.Jumpvalley.Core.Music
 {
     /// <summary>
     /// Represents a musical playlist that can hold multiple Songs

--- a/src/core/Music/Song.cs
+++ b/src/core/Music/Song.cs
@@ -1,9 +1,9 @@
 using Godot;
 using System.IO;
 
-using Jumpvalley.Audio;
+using UTheCat.Jumpvalley.Core.Audio;
 
-namespace Jumpvalley.Music
+namespace UTheCat.Jumpvalley.Core.Music
 {
     /// <summary>
     /// Represents a single song associated with a file, along with some metadata

--- a/src/core/Music/SongChangedArgs.cs
+++ b/src/core/Music/SongChangedArgs.cs
@@ -1,4 +1,4 @@
-namespace Jumpvalley.Music
+namespace UTheCat.Jumpvalley.Core.Music
 {
     /// <summary>
     /// Event arguments for <see cref="Playlist.SongChanged"/> and <see cref="MusicPlayer.SongChanged"/>

--- a/src/core/Music/SongInfo.cs
+++ b/src/core/Music/SongInfo.cs
@@ -1,8 +1,8 @@
 using System.Text.Json.Nodes;
 
-using Jumpvalley.IO;
+using UTheCat.Jumpvalley.Core.IO;
 
-namespace Jumpvalley.Music
+namespace UTheCat.Jumpvalley.Core.Music
 {
     /// <summary>
     /// Class that holds some metadata about a song file.

--- a/src/core/Music/SongInfoFile.cs
+++ b/src/core/Music/SongInfoFile.cs
@@ -1,4 +1,4 @@
-﻿namespace Jumpvalley.Music
+﻿namespace UTheCat.Jumpvalley.Core.Music
 {
     /// <summary>
     /// Reads the associated "info.txt" file for a song.

--- a/src/core/Music/SongPackage.cs
+++ b/src/core/Music/SongPackage.cs
@@ -2,9 +2,9 @@
 using System;
 using System.Text.Json.Nodes;
 
-using Jumpvalley.IO;
+using UTheCat.Jumpvalley.Core.IO;
 
-namespace Jumpvalley.Music
+namespace UTheCat.Jumpvalley.Core.Music
 {
     /// <summary>
     /// Represents a folder (such as one on the filesystem) that contains a song and its info metadata.

--- a/src/core/Players/Camera/BaseCamera.cs
+++ b/src/core/Players/Camera/BaseCamera.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Jumpvalley.Players.Camera
+namespace UTheCat.Jumpvalley.Core.Players.Camera
 {
     /// <summary>
     /// The base class that handles a 3d camera focusing on a 3d object. It includes support for camera panning and zoom controls.

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -1,10 +1,10 @@
 ﻿using Godot;
-using Jumpvalley.Logging;
-using Jumpvalley.Players.Camera;
-using Jumpvalley.Raycasting;
+using UTheCat.Jumpvalley.Core.Logging;
+using UTheCat.Jumpvalley.Core.Players.Camera;
+using UTheCat.Jumpvalley.Core.Raycasting;
 using System;
 
-namespace Jumpvalley.Players.Movement
+namespace UTheCat.Jumpvalley.Core.Players.Movement
 {
     /// <summary>
     /// This is the base class that provides a player's character the ability to move in different directions, jump, and climb.

--- a/src/core/Players/Movement/BodyRotator.cs
+++ b/src/core/Players/Movement/BodyRotator.cs
@@ -1,7 +1,7 @@
 ﻿using Godot;
 using System;
 
-namespace Jumpvalley.Players.Movement
+namespace UTheCat.Jumpvalley.Core.Players.Movement
 {
     /// <summary>
     /// This class is responsible for turning a 3D body's yaw angle in the direction that it's moving.

--- a/src/core/Players/Movement/BodyStateChangedArgs.cs
+++ b/src/core/Players/Movement/BodyStateChangedArgs.cs
@@ -1,4 +1,4 @@
-﻿namespace Jumpvalley.Players.Movement
+﻿namespace UTheCat.Jumpvalley.Core.Players.Movement
 {
     /// <summary>
     /// Event arguments for <see cref="BaseMover.BodyStateChanged"/>.

--- a/src/core/Players/Movement/Climber.cs
+++ b/src/core/Players/Movement/Climber.cs
@@ -1,7 +1,7 @@
 ﻿using Godot;
 using System;
 
-namespace Jumpvalley.Players.Movement
+namespace UTheCat.Jumpvalley.Core.Players.Movement
 {
     /// <summary>
     /// Allows a character to climb objects. Specifically, these objects are <see cref="PhysicsBody3D"/>s

--- a/src/core/Players/Player.cs
+++ b/src/core/Players/Player.cs
@@ -2,13 +2,13 @@
 using System;
 using System.Collections.Generic;
 
-using Jumpvalley.Levels.Interactives;
-using Jumpvalley.Music;
-using Jumpvalley.Players.Camera;
-using Jumpvalley.Players.Movement;
-using Jumpvalley.Timing;
+using UTheCat.Jumpvalley.Core.Levels.Interactives;
+using UTheCat.Jumpvalley.Core.Music;
+using UTheCat.Jumpvalley.Core.Players.Camera;
+using UTheCat.Jumpvalley.Core.Players.Movement;
+using UTheCat.Jumpvalley.Core.Timing;
 
-namespace Jumpvalley.Players
+namespace UTheCat.Jumpvalley.Core.Players
 {
     /// <summary>
     /// This class represents a player who is playing Jumpvalley or some other app that derives from it.

--- a/src/core/Raycasting/RaycastSweep.cs
+++ b/src/core/Raycasting/RaycastSweep.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Jumpvalley.Raycasting
+namespace UTheCat.Jumpvalley.Core.Raycasting
 {
     /// <summary>
     /// Sweeps over a region of 3D space using a series of equally-spaced-out raycasts.

--- a/src/core/Raycasting/RaycastSweepResult.cs
+++ b/src/core/Raycasting/RaycastSweepResult.cs
@@ -1,6 +1,6 @@
 ﻿using Godot;
 
-namespace Jumpvalley.Raycasting
+namespace UTheCat.Jumpvalley.Core.Raycasting
 {
     /// <summary>
     /// Class that contains data about the result of a raycast sweep operation

--- a/src/core/Timing/OffsetStopwatch.cs
+++ b/src/core/Timing/OffsetStopwatch.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace Jumpvalley.Timing
+namespace UTheCat.Jumpvalley.Core.Timing
 {
     /// <summary>
     /// This class extends the <see cref="Stopwatch"/> (in the standard C# library) so that an initial value for elapsed time can be specified.

--- a/src/core/Timing/SpeedrunTimeFormatter.cs
+++ b/src/core/Timing/SpeedrunTimeFormatter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Jumpvalley.Timing
+namespace UTheCat.Jumpvalley.Core.Timing
 {
     /// <summary>
     /// For a given number of seconds, this class helps to format that number into the speedrun time format (minutes:seconds.fractional_seconds).

--- a/src/core/Tweening/IntervalTween.cs
+++ b/src/core/Tweening/IntervalTween.cs
@@ -2,7 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Timers;
 
-namespace Jumpvalley.Tweening
+namespace UTheCat.Jumpvalley.Core.Tweening
 {
     /// <summary>
     /// Class that runs a tween by incrementing steps at a specified time interval.

--- a/src/core/Tweening/MethodTween.cs
+++ b/src/core/Tweening/MethodTween.cs
@@ -2,7 +2,7 @@ using Godot;
 using System;
 using System.Diagnostics;
 
-namespace Jumpvalley.Tweening
+namespace UTheCat.Jumpvalley.Core.Tweening
 {
     /// <summary>
     /// Provides a way of tweening via Godot using method overrides.

--- a/src/core/Tweening/SceneTreeTween.cs
+++ b/src/core/Tweening/SceneTreeTween.cs
@@ -1,6 +1,6 @@
 ﻿using Godot;
 
-namespace Jumpvalley.Tweening
+namespace UTheCat.Jumpvalley.Core.Tweening
 {
     /// <summary>
     /// <see cref="MethodTween"/> that can bind to the Process step of a Godot scene tree.

--- a/src/core/Tweening/TweenGroup.cs
+++ b/src/core/Tweening/TweenGroup.cs
@@ -1,7 +1,7 @@
 using Godot;
 using System.Collections.Generic;
 
-namespace Jumpvalley.Tweening
+namespace UTheCat.Jumpvalley.Core.Tweening
 {
     /// <summary>
     /// A class capable of overseeing multiple tweens as a "group".


### PR DESCRIPTION
This PR puts classes in Jumpvalley's core API under new namespaces. Previously, these classes were under the `Jumpvalley.*` namespaces. As of this PR, these classes are under the `UTheCat.Jumpvalley.Core.*` namespaces.

For example, this PR moves the `Playlist` class from the `Jumpvalley.Music` namespace to the `UTheCat.Jumpvalley.Core.Music` namespace.

This change was made mainly for 3 reasons:

- To heavily reduce the chance of naming conflicts
- To better organize Jumpvalley's codebase
- To prepare for the split of Jumpvalley's codebase into multiple repositories (on hold as of writing)

Because this PR puts the core API's code under new namespaces, backwards-compatibility is broken as a result. Developers using Jumpvalley's Core API will have to refactor their code to accommodate for this change.