### PR TITLE
Fix and change difficulty colors

### DIFF
--- a/src/app/JumpvalleyPlayer.cs
+++ b/src/app/JumpvalleyPlayer.cs
@@ -355,6 +355,7 @@ namespace JumpvalleyApp
 
             // Test difficulty colors
             Testing.DifficultyColorTest difficultyColorTest = new Testing.DifficultyColorTest();
+            difficultyColorTest.TextOutlineSize = 2;
             Disposables.Add(difficultyColorTest);
             PrimaryGui.AddChild(difficultyColorTest.UIGrid);
 

--- a/src/app/JumpvalleyPlayer.cs
+++ b/src/app/JumpvalleyPlayer.cs
@@ -353,12 +353,6 @@ namespace JumpvalleyApp
                 logger.Print($"Failed to load a level at app initialization. The root node of the main scene is missing a node named '{levelsNodeName}'.");
             }
 
-            // Test difficulty colors
-            Testing.DifficultyColorTest difficultyColorTest = new Testing.DifficultyColorTest();
-            difficultyColorTest.TextOutlineSize = 2;
-            Disposables.Add(difficultyColorTest);
-            PrimaryGui.AddChild(difficultyColorTest.UIGrid);
-
             // Start playing music.
             // This is done after we load the lobby and the initialization level just to keep things smooth.
             if (CurrentMusicPlayer.GetParent() == null) RootNode.AddChild(CurrentMusicPlayer);

--- a/src/app/JumpvalleyPlayer.cs
+++ b/src/app/JumpvalleyPlayer.cs
@@ -353,6 +353,11 @@ namespace JumpvalleyApp
                 logger.Print($"Failed to load a level at app initialization. The root node of the main scene is missing a node named '{levelsNodeName}'.");
             }
 
+            // Test difficulty colors
+            Testing.DifficultyColorTest difficultyColorTest = new Testing.DifficultyColorTest();
+            Disposables.Add(difficultyColorTest);
+            PrimaryGui.AddChild(difficultyColorTest.UIGrid);
+
             // Start playing music.
             // This is done after we load the lobby and the initialization level just to keep things smooth.
             if (CurrentMusicPlayer.GetParent() == null) RootNode.AddChild(CurrentMusicPlayer);

--- a/src/app/Testing/DifficultyColorTest.cs
+++ b/src/app/Testing/DifficultyColorTest.cs
@@ -1,0 +1,24 @@
+using Godot;
+
+using UTheCat.Jumpvalley.Core.Levels;
+
+namespace JumpvalleyApp.Testing
+{
+    /// <summary>
+    /// A test that allows a user to see what the difficulty colors of Jumpvalley's primary difficulties would look like.
+    /// </summary>
+    public partial class DifficultyColorTest : System.IDisposable
+    {
+        private Panel panel;
+
+        public DifficultyColorTest()
+        {
+            
+        }
+
+        public void Dispose()
+        {
+            panel.Dispose();
+        }
+    }
+}

--- a/src/app/Testing/DifficultyColorTest.cs
+++ b/src/app/Testing/DifficultyColorTest.cs
@@ -1,4 +1,5 @@
 using Godot;
+using System.Collections.Generic;
 
 using UTheCat.Jumpvalley.Core.Levels;
 
@@ -12,7 +13,21 @@ namespace JumpvalleyApp.Testing
         private readonly string TEST_LEVEL_NAME = "A Mess of Parts";
         private readonly string TEST_LEVEL_AUTHOR = "DifficultyColorTester";
 
+        private List<LabelSettings> labelSettingsList = new List<LabelSettings>();
+
         public GridContainer UIGrid { get; private set; }
+
+        private int _textOutlineSize = 0;
+        public int TextOutlineSize
+        {
+            get => _textOutlineSize;
+            set
+            {
+                _textOutlineSize = value;
+
+                foreach (LabelSettings l in labelSettingsList) l.OutlineSize = value;
+            }
+        }
 
         public DifficultyColorTest()
         {
@@ -25,8 +40,11 @@ namespace JumpvalleyApp.Testing
 
                 LabelSettings labelSettings = new LabelSettings();
                 labelSettings.FontColor = d.Color;
+                labelSettings.OutlineColor = new Color(0f, 0f, 0f);
+                labelSettings.OutlineSize = _textOutlineSize;
 
                 label.LabelSettings = labelSettings;
+                labelSettingsList.Add(labelSettings);
                 UIGrid.AddChild(label);
             }
         }

--- a/src/app/Testing/DifficultyColorTest.cs
+++ b/src/app/Testing/DifficultyColorTest.cs
@@ -9,16 +9,32 @@ namespace JumpvalleyApp.Testing
     /// </summary>
     public partial class DifficultyColorTest : System.IDisposable
     {
-        private Panel panel;
+        private readonly string TEST_LEVEL_NAME = "A Mess of Parts";
+        private readonly string TEST_LEVEL_AUTHOR = "DifficultyColorTester";
+
+        public GridContainer UIGrid { get; private set; }
 
         public DifficultyColorTest()
         {
-            
+            UIGrid = new GridContainer();
+
+            foreach (Difficulty d in DifficultyPresets.PRIMARY_DIFFICULTIES.Difficulties)
+            {
+                Label label = new Label();
+                label.Text = $"{TEST_LEVEL_NAME} by {TEST_LEVEL_AUTHOR} [{d.Name} - {d.Rating}]";
+
+                LabelSettings labelSettings = new LabelSettings();
+                labelSettings.FontColor = d.Color;
+
+                label.LabelSettings = labelSettings;
+                UIGrid.AddChild(label);
+            }
         }
 
         public void Dispose()
         {
-            panel.Dispose();
+            UIGrid.QueueFree();
+            UIGrid.Dispose();
         }
     }
 }

--- a/src/app/Testing/DifficultyColorTest.cs.uid
+++ b/src/app/Testing/DifficultyColorTest.cs.uid
@@ -1,0 +1,1 @@
+uid://dxne35ouuprvw

--- a/src/core/Levels/DifficultyPresets.cs
+++ b/src/core/Levels/DifficultyPresets.cs
@@ -31,14 +31,14 @@ namespace UTheCat.Jumpvalley.Core.Levels
         public readonly static DifficultySet PRIMARY_DIFFICULTIES = new DifficultySet(
             new List<Difficulty>()
             {
-                new Difficulty("Beginner", 0.0, new Color(90f / 360f, 0.41f, 1f)),
-                new Difficulty("Intermediate", 20.0, new Color(60f / 360f, 0.41f, 1f)),
-                new Difficulty("Advanced", 40.0, new Color(30f / 360f, 0.41f, 1f)),
-                new Difficulty("Expert", 60.0, new Color(0f / 360f, 0.41f, 1f)),
-                new Difficulty("Grandmaster", 80.0, new Color(330f / 360f, 0.41f, 1f)),
-                new Difficulty("GM+1", 100.0, new Color(300f / 360f, 0.41f, 1f)),
-                new Difficulty("GM+2", 120.0, new Color(270f / 360f, 0.41f, 1f)),
-                new Difficulty("GM+3", 140.0, new Color(240f / 360f, 0.41f, 1f))
+                new Difficulty("Beginner", 0.0, Color.FromHsv(90f / 360f, 0.41f, 1f)),
+                new Difficulty("Intermediate", 20.0, Color.FromHsv(60f / 360f, 0.41f, 1f)),
+                new Difficulty("Advanced", 40.0, Color.FromHsv(30f / 360f, 0.41f, 1f)),
+                new Difficulty("Expert", 60.0, Color.FromHsv(0f / 360f, 0.41f, 1f)),
+                new Difficulty("Grandmaster", 80.0, Color.FromHsv(330f / 360f, 0.41f, 1f)),
+                new Difficulty("GM+1", 100.0, Color.FromHsv(300f / 360f, 0.41f, 1f)),
+                new Difficulty("GM+2", 120.0, Color.FromHsv(270f / 360f, 0.41f, 1f)),
+                new Difficulty("GM+3", 140.0, Color.FromHsv(240f / 360f, 0.41f, 1f))            
             }
         );
     }

--- a/src/core/Levels/DifficultyPresets.cs
+++ b/src/core/Levels/DifficultyPresets.cs
@@ -32,13 +32,13 @@ namespace UTheCat.Jumpvalley.Core.Levels
             new List<Difficulty>()
             {
                 new Difficulty("Beginner", 0.0, new Color(90f / 360f, 0.41f, 1f)),
-                new Difficulty("Intermediate", 20.0, new Color(60f / 360f, 0.44f, 1f)),
-                new Difficulty("Advanced", 40.0, new Color(30f / 360f, 0.47f, 0.88f)),
-                new Difficulty("Expert", 60.0, new Color(0f / 360f, 0.53f, 1f)),
-                new Difficulty("Grandmaster", 80.0, new Color(330f / 360f, 0.47f, 1f)),
-                new Difficulty("GM+1", 100.0, new Color(300f / 360f, 0.55f, 1f)),
-                new Difficulty("GM+2", 120.0, new Color(270f / 360f, 0.6f, 1f)),
-                new Difficulty("GM+3", 140.0, new Color(240f / 360f, 0.92f, 1f)),
+                new Difficulty("Intermediate", 20.0, new Color(60f / 360f, 0.41f, 1f)),
+                new Difficulty("Advanced", 40.0, new Color(30f / 360f, 0.41f, 1f)),
+                new Difficulty("Expert", 60.0, new Color(0f / 360f, 0.41f, 1f)),
+                new Difficulty("Grandmaster", 80.0, new Color(330f / 360f, 0.41f, 1f)),
+                new Difficulty("GM+1", 100.0, new Color(300f / 360f, 0.41f, 1f)),
+                new Difficulty("GM+2", 120.0, new Color(270f / 360f, 0.41f, 1f)),
+                new Difficulty("GM+3", 140.0, new Color(240f / 360f, 0.41f, 1f))
             }
         );
     }

--- a/src/core/Levels/DifficultyPresets.cs
+++ b/src/core/Levels/DifficultyPresets.cs
@@ -31,14 +31,14 @@ namespace UTheCat.Jumpvalley.Core.Levels
         public readonly static DifficultySet PRIMARY_DIFFICULTIES = new DifficultySet(
             new List<Difficulty>()
             {
-                new Difficulty("Beginner", 0.0, Color.FromHsv(90f / 360f, 0.41f, 1f)),
-                new Difficulty("Intermediate", 20.0, Color.FromHsv(60f / 360f, 0.41f, 1f)),
-                new Difficulty("Advanced", 40.0, Color.FromHsv(30f / 360f, 0.41f, 1f)),
-                new Difficulty("Expert", 60.0, Color.FromHsv(0f / 360f, 0.41f, 1f)),
-                new Difficulty("Grandmaster", 80.0, Color.FromHsv(330f / 360f, 0.41f, 1f)),
-                new Difficulty("GM+1", 100.0, Color.FromHsv(300f / 360f, 0.41f, 1f)),
-                new Difficulty("GM+2", 120.0, Color.FromHsv(270f / 360f, 0.41f, 1f)),
-                new Difficulty("GM+3", 140.0, Color.FromHsv(240f / 360f, 0.41f, 1f))            
+                new Difficulty("Beginner", 0.0, Color.FromHsv(90f / 360f, 0.6f, 1f)),
+                new Difficulty("Intermediate", 20.0, Color.FromHsv(60f / 360f, 0.6f, 1f)),
+                new Difficulty("Advanced", 40.0, Color.FromHsv(30f / 360f, 0.6f, 1f)),
+                new Difficulty("Expert", 60.0, Color.FromHsv(0f / 360f, 0.6f, 1f)),
+                new Difficulty("Grandmaster", 80.0, Color.FromHsv(330f / 360f, 0.6f, 1f)),
+                new Difficulty("GM+1", 100.0, Color.FromHsv(300f / 360f, 0.6f, 1f)),
+                new Difficulty("GM+2", 120.0, Color.FromHsv(270f / 360f, 0.6f, 1f)),
+                new Difficulty("GM+3", 140.0, Color.FromHsv(240f / 360f, 0.6f, 1f))
             }
         );
     }


### PR DESCRIPTION
This PR is both a fix and a change. The PR is a fix because the difficulty colors no longer look like only 2 colors are used. This PR is also a change because the colors of every difficulty in the "primary difficulties" list ("Beginner", "Intermediate", "Advanced", "Expert", "Grandmaster", "GM+1", "GM+2", and "GM+3") have been changed from what they previously were supposed to be.

Here's the result:
![Screenshot_20250401_014801.png](https://github.com/user-attachments/assets/6f390a1b-57d8-438a-8219-d52af4558963)
