### PR TITLE
Change type of LevelInfo.LevelDifficulty property to double

### DIFF
--- a/src/app/JumpvalleyPlayer.cs
+++ b/src/app/JumpvalleyPlayer.cs
@@ -343,7 +343,7 @@ namespace JumpvalleyApp
                     if (levelPackage != null)
                     {
                         LevelInfo levelInfo = levelPackage.Info;
-                        Difficulty difficulty = levelInfo.LevelDifficulty;
+                        Difficulty difficulty = DifficultyPresets.PRIMARY_DIFFICULTIES.GetDifficultyByRating(levelInfo.LevelDifficulty);
                         logger.Print($"Now playing a level: {levelInfo.FullName} by {levelInfo.Creators} [{difficulty.Name} - {difficulty.Rating}]");
                     }
                 }

--- a/src/app/Testing/LevelLoadingTest.cs
+++ b/src/app/Testing/LevelLoadingTest.cs
@@ -86,7 +86,7 @@ namespace JumpvalleyApp.Testing
             RootNodeParent?.AddChild(level.RootNode);
 
             LevelInfo levelInfo = level.Info;
-            Difficulty difficulty = levelInfo.LevelDifficulty;
+            Difficulty difficulty = DifficultyPresets.PRIMARY_DIFFICULTIES.GetDifficultyByRating(levelInfo.LevelDifficulty);
             Console.WriteLine($"Now playing: {levelInfo.FullName} by {levelInfo.Creators} [{difficulty.Name} - {difficulty.Rating}]");
 
             IsProcessStepConnected = true;

--- a/src/core/Levels/LevelInfo.cs
+++ b/src/core/Levels/LevelInfo.cs
@@ -32,7 +32,7 @@ namespace UTheCat.Jumpvalley.Core.Levels
         /// <summary>
         /// How difficult the level is.
         /// </summary>
-        public Difficulty LevelDifficulty;
+        public double LevelDifficulty;
 
         /// <summary>
         /// The file path to the scene file that contains the level, including the file name and extension. This path should typically be relative to the level's root folder.

--- a/src/core/Levels/LevelInfo.cs
+++ b/src/core/Levels/LevelInfo.cs
@@ -31,6 +31,9 @@ namespace UTheCat.Jumpvalley.Core.Levels
 
         /// <summary>
         /// How difficult the level is.
+        /// <br/><br/>
+        /// As far as <see cref="LevelInfo"/> is concerned, this is just a number.
+        /// It's up to the developer or user to assign meaning to this number.
         /// </summary>
         public double LevelDifficulty;
 

--- a/src/core/Levels/LevelInfo.cs
+++ b/src/core/Levels/LevelInfo.cs
@@ -49,19 +49,7 @@ namespace UTheCat.Jumpvalley.Core.Levels
             ScenePath = data["scenePath"]?.GetValue<string>();
 
             JsonNode difficultyNode = data["difficulty"];
-            if (difficultyNode == null)
-            {
-                LevelDifficulty = null;
-            }
-            else
-            {
-                // In a level's JSON info file, the difficulty is stored as a number.
-                double difficultyRating = difficultyNode.GetValue<double>();
-
-                // We'll need to retain the exact numerical difficulty when setting LevelDifficulty
-                Difficulty difficulty = DifficultyPresets.PRIMARY_DIFFICULTIES.GetDifficultyByRating(difficultyRating);
-                LevelDifficulty = new Difficulty(difficulty.Name, difficultyRating, difficulty.Color);
-            }
+            LevelDifficulty = (difficultyNode == null) ? 0.0 : difficultyNode.GetValue<double>();
         }
     }
 }


### PR DESCRIPTION
This PR changes the type of the `LevelDifficulty` property in the `LevelInfo` class from `Difficulty` to `double`.

This change has these advantages:

- Less memory usage
- More flexibility as to how `LevelInfo.LevelDifficulty` should be interpreted. 3rd-party apps using the `LevelInfo` class might use a different difficulty rating system than the one Jumpvalley uses, or perhaps the numeric difficulty specified by a level is supposed to be interpreted differently from what `DifficultyPresets.PRIMARY_DIFFICULTIES` specifies. By having LevelInfo store a level's difficulty merely as a number, developers have more control over what this number says about a level.

With that being said, this API change is breaking; code that accesses `LevelInfo.LevelDifficulty` may have to be modified as a result.