### PR TITLE
Increase max framerate

### DIFF
--- a/src/app/Gui/RenderFramerateLimiter.cs
+++ b/src/app/Gui/RenderFramerateLimiter.cs
@@ -14,7 +14,7 @@ namespace UTheCat.Jumpvalley.App.Gui
         /// <summary>
         /// The minimum difference between the maximum rendering frames-per-second and the monitor's refresh rate
         /// </summary>
-        public float MinFpsDifference = 0.5f;
+        public float MinFpsDifference = 0f;
 
         /// <summary>
         /// The maximum difference between the maximum rendering frames-per-second and the monitor's refresh rate

--- a/src/app/Gui/RenderFramerateLimiter.cs
+++ b/src/app/Gui/RenderFramerateLimiter.cs
@@ -64,10 +64,7 @@ namespace UTheCat.Jumpvalley.App.Gui
             float refreshRate = DisplayServer.ScreenGetRefreshRate();
 
             // If ScreenGetRefreshRate fails, it returns -1
-            if (refreshRate < 0)
-            {
-                return;
-            }
+            if (refreshRate < 0) return;
 
             int maxFps = (int)Math.Floor((refreshRate - MinFpsDifference) * 2.0);
 

--- a/src/app/Gui/RenderFramerateLimiter.cs
+++ b/src/app/Gui/RenderFramerateLimiter.cs
@@ -66,7 +66,7 @@ namespace UTheCat.Jumpvalley.App.Gui
             // If ScreenGetRefreshRate fails, it returns -1
             if (refreshRate < 0) return;
 
-            int maxFps = (int)Math.Floor((refreshRate - MinFpsDifference) * 2.0);
+            int maxFps = (int)Math.Round((refreshRate - MinFpsDifference) * 2.0);
 
             if (MaxFps == maxFps) return;
 

--- a/src/app/Gui/RenderFramerateLimiter.cs
+++ b/src/app/Gui/RenderFramerateLimiter.cs
@@ -24,7 +24,7 @@ namespace UTheCat.Jumpvalley.App.Gui
         /// <summary>
         /// The current maximum framerate enforced by this <see cref="RenderFramerateLimiter"/>
         /// </summary>
-        public int MaxFps { get; private set; } = 60;
+        public int MaxFps { get; private set; } = 120;
 
         public bool _isRunning = false;
 
@@ -69,7 +69,7 @@ namespace UTheCat.Jumpvalley.App.Gui
                 return;
             }
 
-            int maxFps = (int)Math.Floor((double)refreshRate - MinFpsDifference);
+            int maxFps = (int)Math.Floor((refreshRate - MinFpsDifference) * 2.0);
 
             if (MaxFps == maxFps) return;
 


### PR DESCRIPTION
As of this PR:

- Max framerate is double your monitor's current refresh rate
- Calculated framerate limit will round to the nearest integer instead of always rounding down