### PR TITLE
Revert back to X11 window system for now

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -28,7 +28,6 @@ window/size/viewport_height=1080
 window/size/window_width_override=1152
 window/size/window_height_override=648
 window/stretch/aspect="expand"
-display_server/driver.linuxbsd="wayland"
 window/vsync/vsync_mode=0
 
 [dotnet]


### PR DESCRIPTION
Reasons for the revert:

- X11 has better compatibility with a wider range of computer setups. This is particularly important for users running Linux using an NVIDIA graphics card.
- X11 currently offers more customization options for display configuration. For example, `xrandr` can be used to disable V-sync whereas Wayland currently requires that the desktop environment and window manager support things like variable refresh rate.
- Currently, Godot can run with V-sync disabled on Gnome using XWayland, but *can't* when running on Gnome and using Wayland (with no X11). Godot limits the app window's FPS to the monitor's refresh rate when the app is forced to run with V-sync enabled, and so to exceed this FPS limit (e.g. for better responsiveness to user input), Godot has to be able to run with v-sync disabled.