### PR TITLE
Improve character physics (changes started on 2025-Apr-18)

### DIFF
--- a/main.tscn
+++ b/main.tscn
@@ -143,6 +143,7 @@ visible = false
 layout_mode = 1
 
 [node name="Character" parent="." instance=ExtResource("9_1wvm3")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 
 [node name="Levels" type="Node3D" parent="."]
 metadata/initialization_level = "res://levels/shape_variety/"

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -198,7 +198,7 @@ metadata/destination_node_path = NodePath("..")
 
 [node name="RigidBody3D" type="RigidBody3D" parent="Interactives"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.5, 7.5, -15.5)
-mass = 10.0
+mass = 0.5
 physics_material_override = SubResource("PhysicsMaterial_yudit")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/RigidBody3D"]
@@ -211,7 +211,7 @@ skeleton = NodePath("../..")
 
 [node name="RigidBody3D2" type="RigidBody3D" parent="Interactives"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15, 2, -22.5)
-mass = 10.0
+mass = 0.5
 physics_material_override = SubResource("PhysicsMaterial_yudit")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/RigidBody3D2"]

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -11,6 +11,7 @@
 [ext_resource type="PackedScene" uid="uid://de3srdhlm3ku8" path="res://scenes/lobby/wallhop_test.tscn" id="9_0j8si"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_yudit"]
+friction = 0.4
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_e5b6p"]
 

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -11,7 +11,7 @@
 [ext_resource type="PackedScene" uid="uid://de3srdhlm3ku8" path="res://scenes/lobby/wallhop_test.tscn" id="9_0j8si"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_yudit"]
-friction = 0.4
+friction = 0.2
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_e5b6p"]
 
@@ -199,6 +199,7 @@ metadata/destination_node_path = NodePath("..")
 
 [node name="RigidBody3D" type="RigidBody3D" parent="Interactives"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.5, 7.5, -15.5)
+mass = 0.25
 physics_material_override = SubResource("PhysicsMaterial_yudit")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/RigidBody3D"]

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -199,7 +199,6 @@ metadata/destination_node_path = NodePath("..")
 
 [node name="RigidBody3D" type="RigidBody3D" parent="Interactives"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.5, 7.5, -15.5)
-mass = 0.25
 physics_material_override = SubResource("PhysicsMaterial_yudit")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/RigidBody3D"]

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -199,7 +199,6 @@ metadata/destination_node_path = NodePath("..")
 
 [node name="RigidBody3D" type="RigidBody3D" parent="Interactives"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.5, 7.5, -15.5)
-mass = 0.5
 physics_material_override = SubResource("PhysicsMaterial_yudit")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/RigidBody3D"]
@@ -212,7 +211,6 @@ skeleton = NodePath("../..")
 
 [node name="RigidBody3D2" type="RigidBody3D" parent="Interactives"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15, 2, -22.5)
-mass = 0.5
 physics_material_override = SubResource("PhysicsMaterial_yudit")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/RigidBody3D2"]

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=62 format=3 uid="uid://dqjghdruydyeo"]
+[gd_scene load_steps=63 format=3 uid="uid://dqjghdruydyeo"]
 
 [ext_resource type="Material" uid="uid://bq3d6llinnd1i" path="res://textures/moveable_object_indicator.tres" id="1_x3ong"]
 [ext_resource type="Texture2D" uid="uid://d0tpyep45doca" path="res://addons/kenney_prototype_textures/light/texture_07.png" id="2_065hl"]
 [ext_resource type="FontFile" uid="uid://b35ldnmoo353w" path="res://addons/fonts/overpass/static/Overpass-Bold.ttf" id="3_7vwr2"]
 [ext_resource type="Texture2D" uid="uid://dcxkj8m3ltdl8" path="res://addons/kenney_prototype_textures/dark/texture_03.png" id="3_mqd1l"]
 [ext_resource type="Texture2D" uid="uid://3ycuod8up64p" path="res://addons/kenney_prototype_textures/dark/texture_01.png" id="4_2jpqx"]
+[ext_resource type="PackedScene" uid="uid://qsfj4a2nteub" path="res://scenes/lobby/pushable_object_grounds.tscn" id="4_hnbc4"]
 [ext_resource type="Material" uid="uid://27np65wgewr4" path="res://scenes/lobby/shape_kit_texture.tres" id="4_xv8fq"]
 [ext_resource type="Material" uid="uid://bm0ukyda3pfcc" path="res://textures/ladder_indicator.tres" id="5_efv4u"]
 [ext_resource type="FontFile" uid="uid://bseob0pnt3rg0" path="res://addons/fonts/overpass/static/Overpass-Regular.ttf" id="6_1tuk3"]
@@ -324,6 +325,9 @@ shape = SubResource("BoxShape3D_dv07x")
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Interactives/StartEndTeleporter/Destination/Platform/CollisionShape3D"]
 material_override = SubResource("StandardMaterial3D_yb2eo")
 mesh = SubResource("BoxMesh_mu0vs")
+
+[node name="PushableObjectGrounds" parent="Interactives" instance=ExtResource("4_hnbc4")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -33, 1, -16)
 
 [node name="SpinningMesh" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, -8)

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -198,7 +198,7 @@ metadata/destination_node_path = NodePath("..")
 
 [node name="RigidBody3D" type="RigidBody3D" parent="Interactives"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.5, 7.5, -15.5)
-mass = 0.01
+mass = 10.0
 physics_material_override = SubResource("PhysicsMaterial_yudit")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/RigidBody3D"]
@@ -211,7 +211,7 @@ skeleton = NodePath("../..")
 
 [node name="RigidBody3D2" type="RigidBody3D" parent="Interactives"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15, 2, -22.5)
-mass = 0.01
+mass = 10.0
 physics_material_override = SubResource("PhysicsMaterial_yudit")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Interactives/RigidBody3D2"]

--- a/scenes/lobby/pushable_object_grounds.tscn
+++ b/scenes/lobby/pushable_object_grounds.tscn
@@ -1,0 +1,123 @@
+[gd_scene load_steps=10 format=3 uid="uid://qsfj4a2nteub"]
+
+[ext_resource type="Material" uid="uid://b26hmg13p2cwv" path="res://scenes/lobby/pushable_object_grounds_frame_texture.tres" id="1_4q5wd"]
+[ext_resource type="Texture2D" uid="uid://d0tpyep45doca" path="res://addons/kenney_prototype_textures/light/texture_07.png" id="1_f7u6v"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_6omsi"]
+size = Vector3(16, 1, 16)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_6reg5"]
+albedo_color = Color(0.28, 0.1484, 0.157173, 1)
+albedo_texture = ExtResource("1_f7u6v")
+uv1_triplanar = true
+
+[sub_resource type="BoxMesh" id="BoxMesh_s4cn0"]
+size = Vector3(16, 1, 16)
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_6mah4"]
+height = 16.25
+radius = 1.0
+
+[sub_resource type="CylinderMesh" id="CylinderMesh_736bf"]
+top_radius = 1.0
+bottom_radius = 1.0
+height = 16.25
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_0j8si"]
+size = Vector3(16, 16, 1)
+
+[sub_resource type="BoxMesh" id="BoxMesh_hnbc4"]
+size = Vector3(16, 16, 1)
+
+[node name="PushableObjectGrounds" type="Node3D"]
+
+[node name="Frame" type="Node3D" parent="."]
+
+[node name="Floor" type="StaticBody3D" parent="Frame"]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Floor"]
+shape = SubResource("BoxShape3D_6omsi")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Floor"]
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_s4cn0")
+
+[node name="StaticBody3D" type="StaticBody3D" parent="Frame/Floor"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8, 7.5, 8)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Floor/StaticBody3D"]
+shape = SubResource("CylinderShape3D_6mah4")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Floor/StaticBody3D"]
+material_override = ExtResource("1_4q5wd")
+mesh = SubResource("CylinderMesh_736bf")
+
+[node name="StaticBody3D2" type="StaticBody3D" parent="Frame/Floor"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8, 7.5, 8)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Floor/StaticBody3D2"]
+shape = SubResource("CylinderShape3D_6mah4")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Floor/StaticBody3D2"]
+material_override = ExtResource("1_4q5wd")
+mesh = SubResource("CylinderMesh_736bf")
+
+[node name="StaticBody3D3" type="StaticBody3D" parent="Frame/Floor"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8, 7.5, -8)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Floor/StaticBody3D3"]
+shape = SubResource("CylinderShape3D_6mah4")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Floor/StaticBody3D3"]
+material_override = ExtResource("1_4q5wd")
+mesh = SubResource("CylinderMesh_736bf")
+
+[node name="StaticBody3D4" type="StaticBody3D" parent="Frame/Floor"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8, 7.5, -8)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Floor/StaticBody3D4"]
+shape = SubResource("CylinderShape3D_6mah4")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Floor/StaticBody3D4"]
+material_override = ExtResource("1_4q5wd")
+mesh = SubResource("CylinderMesh_736bf")
+
+[node name="Box" type="StaticBody3D" parent="Frame"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 7.5, -8.5)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Box"]
+shape = SubResource("BoxShape3D_0j8si")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Box"]
+material_override = ExtResource("1_4q5wd")
+mesh = SubResource("BoxMesh_hnbc4")
+
+[node name="Box2" type="StaticBody3D" parent="Frame"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 7.5, 8.5)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Box2"]
+shape = SubResource("BoxShape3D_0j8si")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Box2"]
+material_override = ExtResource("1_4q5wd")
+mesh = SubResource("BoxMesh_hnbc4")
+
+[node name="Box3" type="StaticBody3D" parent="Frame"]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, -8.5, 7.5, 0)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Box3"]
+shape = SubResource("BoxShape3D_0j8si")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Box3"]
+material_override = ExtResource("1_4q5wd")
+mesh = SubResource("BoxMesh_hnbc4")
+
+[node name="Box4" type="StaticBody3D" parent="Frame"]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 8.5, 7.5, 0)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Box4"]
+shape = SubResource("BoxShape3D_0j8si")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Box4"]
+material_override = ExtResource("1_4q5wd")
+mesh = SubResource("BoxMesh_hnbc4")

--- a/scenes/lobby/pushable_object_grounds.tscn
+++ b/scenes/lobby/pushable_object_grounds.tscn
@@ -14,6 +14,12 @@ uv1_triplanar = true
 [sub_resource type="BoxMesh" id="BoxMesh_s4cn0"]
 size = Vector3(16, 1, 16)
 
+[sub_resource type="BoxShape3D" id="BoxShape3D_0j8si"]
+size = Vector3(16, 16, 1)
+
+[sub_resource type="BoxMesh" id="BoxMesh_hnbc4"]
+size = Vector3(16, 16, 1)
+
 [sub_resource type="CylinderShape3D" id="CylinderShape3D_6mah4"]
 height = 16.25
 radius = 1.0
@@ -22,12 +28,6 @@ radius = 1.0
 top_radius = 1.0
 bottom_radius = 1.0
 height = 16.25
-
-[sub_resource type="BoxShape3D" id="BoxShape3D_0j8si"]
-size = Vector3(16, 16, 1)
-
-[sub_resource type="BoxMesh" id="BoxMesh_hnbc4"]
-size = Vector3(16, 16, 1)
 
 [node name="PushableObjectGrounds" type="Node3D"]
 
@@ -41,46 +41,6 @@ shape = SubResource("BoxShape3D_6omsi")
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Floor"]
 material_override = SubResource("StandardMaterial3D_6reg5")
 mesh = SubResource("BoxMesh_s4cn0")
-
-[node name="StaticBody3D" type="StaticBody3D" parent="Frame/Floor"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8, 7.5, 8)
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Floor/StaticBody3D"]
-shape = SubResource("CylinderShape3D_6mah4")
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Floor/StaticBody3D"]
-material_override = ExtResource("1_4q5wd")
-mesh = SubResource("CylinderMesh_736bf")
-
-[node name="StaticBody3D2" type="StaticBody3D" parent="Frame/Floor"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8, 7.5, 8)
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Floor/StaticBody3D2"]
-shape = SubResource("CylinderShape3D_6mah4")
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Floor/StaticBody3D2"]
-material_override = ExtResource("1_4q5wd")
-mesh = SubResource("CylinderMesh_736bf")
-
-[node name="StaticBody3D3" type="StaticBody3D" parent="Frame/Floor"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8, 7.5, -8)
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Floor/StaticBody3D3"]
-shape = SubResource("CylinderShape3D_6mah4")
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Floor/StaticBody3D3"]
-material_override = ExtResource("1_4q5wd")
-mesh = SubResource("CylinderMesh_736bf")
-
-[node name="StaticBody3D4" type="StaticBody3D" parent="Frame/Floor"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8, 7.5, -8)
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Floor/StaticBody3D4"]
-shape = SubResource("CylinderShape3D_6mah4")
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Floor/StaticBody3D4"]
-material_override = ExtResource("1_4q5wd")
-mesh = SubResource("CylinderMesh_736bf")
 
 [node name="Box" type="StaticBody3D" parent="Frame"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 7.5, -8.5)
@@ -121,3 +81,45 @@ shape = SubResource("BoxShape3D_0j8si")
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Box4"]
 material_override = ExtResource("1_4q5wd")
 mesh = SubResource("BoxMesh_hnbc4")
+
+[node name="Cylinder4" type="StaticBody3D" parent="Frame"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8, 7.5, 8)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Cylinder4"]
+shape = SubResource("CylinderShape3D_6mah4")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Cylinder4"]
+material_override = ExtResource("1_4q5wd")
+mesh = SubResource("CylinderMesh_736bf")
+
+[node name="Cylinder5" type="StaticBody3D" parent="Frame"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8, 7.5, 8)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Cylinder5"]
+shape = SubResource("CylinderShape3D_6mah4")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Cylinder5"]
+material_override = ExtResource("1_4q5wd")
+mesh = SubResource("CylinderMesh_736bf")
+
+[node name="Cylinder6" type="StaticBody3D" parent="Frame"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8, 7.5, -8)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Cylinder6"]
+shape = SubResource("CylinderShape3D_6mah4")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Cylinder6"]
+material_override = ExtResource("1_4q5wd")
+mesh = SubResource("CylinderMesh_736bf")
+
+[node name="Cylinder7" type="StaticBody3D" parent="Frame"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8, 7.5, -8)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Frame/Cylinder7"]
+shape = SubResource("CylinderShape3D_6mah4")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Frame/Cylinder7"]
+material_override = ExtResource("1_4q5wd")
+mesh = SubResource("CylinderMesh_736bf")
+
+[node name="Ladder" type="Node3D" parent="."]

--- a/scenes/lobby/pushable_object_grounds.tscn
+++ b/scenes/lobby/pushable_object_grounds.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://qsfj4a2nteub"]
+[gd_scene load_steps=12 format=3 uid="uid://qsfj4a2nteub"]
 
 [ext_resource type="Material" uid="uid://b26hmg13p2cwv" path="res://scenes/lobby/pushable_object_grounds_frame_texture.tres" id="1_4q5wd"]
 [ext_resource type="Texture2D" uid="uid://d0tpyep45doca" path="res://addons/kenney_prototype_textures/light/texture_07.png" id="1_f7u6v"]
@@ -28,6 +28,12 @@ radius = 1.0
 top_radius = 1.0
 bottom_radius = 1.0
 height = 16.25
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_f7u6v"]
+size = Vector3(2, 15.5, 2)
+
+[sub_resource type="BoxMesh" id="BoxMesh_6omsi"]
+size = Vector3(2, 0.5, 2)
 
 [node name="PushableObjectGrounds" type="Node3D"]
 
@@ -122,4 +128,89 @@ shape = SubResource("CylinderShape3D_6mah4")
 material_override = ExtResource("1_4q5wd")
 mesh = SubResource("CylinderMesh_736bf")
 
-[node name="Ladder" type="Node3D" parent="."]
+[node name="Ladder" type="StaticBody3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 7.5, 8.5)
+metadata/is_climbable = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Ladder"]
+shape = SubResource("BoxShape3D_f7u6v")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -7.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D2" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -6.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D3" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -5.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D4" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -4.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D5" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -3.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D6" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D7" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D8" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D9" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D10" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D11" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D12" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D13" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D14" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D15" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 6.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")
+
+[node name="MeshInstance3D16" type="MeshInstance3D" parent="Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 7.5, 0)
+material_override = SubResource("StandardMaterial3D_6reg5")
+mesh = SubResource("BoxMesh_6omsi")

--- a/scenes/lobby/pushable_object_grounds.tscn
+++ b/scenes/lobby/pushable_object_grounds.tscn
@@ -1,7 +1,36 @@
-[gd_scene load_steps=12 format=3 uid="uid://qsfj4a2nteub"]
+[gd_scene load_steps=21 format=3 uid="uid://qsfj4a2nteub"]
 
 [ext_resource type="Material" uid="uid://b26hmg13p2cwv" path="res://scenes/lobby/pushable_object_grounds_frame_texture.tres" id="1_4q5wd"]
+[ext_resource type="Material" uid="uid://bq3d6llinnd1i" path="res://textures/moveable_object_indicator.tres" id="1_6omsi"]
 [ext_resource type="Texture2D" uid="uid://d0tpyep45doca" path="res://addons/kenney_prototype_textures/light/texture_07.png" id="1_f7u6v"]
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_f7u6v"]
+
+[sub_resource type="SphereMesh" id="SphereMesh_6omsi"]
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_6omsi"]
+radius = 1.0
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_s4cn0"]
+albedo_color = Color(1, 0.658667, 0.36, 1)
+albedo_texture = ExtResource("1_f7u6v")
+uv1_triplanar = true
+
+[sub_resource type="SphereMesh" id="SphereMesh_6mah4"]
+radius = 1.0
+height = 2.0
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_6reg5"]
+radius = 1.5
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_6mah4"]
+albedo_color = Color(0.36, 0.488, 1, 1)
+albedo_texture = ExtResource("1_f7u6v")
+uv1_triplanar = true
+
+[sub_resource type="SphereMesh" id="SphereMesh_736bf"]
+radius = 1.5
+height = 3.0
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_6omsi"]
 size = Vector3(16, 1, 16)
@@ -36,6 +65,40 @@ size = Vector3(2, 15.5, 2)
 size = Vector3(2, 0.5, 2)
 
 [node name="PushableObjectGrounds" type="Node3D"]
+
+[node name="PushableObjects" type="Node3D" parent="."]
+
+[node name="Ball" type="RigidBody3D" parent="PushableObjects"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="PushableObjects/Ball"]
+shape = SubResource("SphereShape3D_f7u6v")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="PushableObjects/Ball"]
+material_override = ExtResource("1_6omsi")
+mesh = SubResource("SphereMesh_6omsi")
+
+[node name="Ball2" type="RigidBody3D" parent="PushableObjects"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 1.5, 0)
+mass = 2.0
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="PushableObjects/Ball2"]
+shape = SubResource("SphereShape3D_6omsi")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="PushableObjects/Ball2"]
+material_override = SubResource("StandardMaterial3D_s4cn0")
+mesh = SubResource("SphereMesh_6mah4")
+
+[node name="Ball3" type="RigidBody3D" parent="PushableObjects"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.25, 2, 2.75)
+mass = 3.0
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="PushableObjects/Ball3"]
+shape = SubResource("SphereShape3D_6reg5")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="PushableObjects/Ball3"]
+material_override = SubResource("StandardMaterial3D_6mah4")
+mesh = SubResource("SphereMesh_736bf")
 
 [node name="Frame" type="Node3D" parent="."]
 

--- a/scenes/lobby/pushable_object_grounds_frame_texture.tres
+++ b/scenes/lobby/pushable_object_grounds_frame_texture.tres
@@ -1,0 +1,8 @@
+[gd_resource type="StandardMaterial3D" load_steps=2 format=3 uid="uid://b26hmg13p2cwv"]
+
+[ext_resource type="Texture2D" uid="uid://d0tpyep45doca" path="res://addons/kenney_prototype_textures/light/texture_07.png" id="1_meywy"]
+
+[resource]
+albedo_color = Color(0.917647, 0.490196, 0.521569, 1)
+albedo_texture = ExtResource("1_meywy")
+uv1_triplanar = true

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -10,7 +10,6 @@ size = Vector3(1, 2, 0.5)
 size = Vector3(1, 2, 0.5)
 
 [node name="Character" type="CharacterBody3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 metadata/custom_overall_bounding_box = AABB(-0.5, -1, -0.25, 1, 2, 0.5)
 
 [node name="_InteractiveBoundingBox" type="Node" parent="."]

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://bhraj4ym0cswa"]
+[gd_scene load_steps=6 format=3 uid="uid://bhraj4ym0cswa"]
 
 [ext_resource type="Material" uid="uid://bmtoyp50ewt6w" path="res://scenes/player/torso_texture.tres" id="1_8fnx3"]
 [ext_resource type="PackedScene" uid="uid://dx0npmluqx167" path="res://scenes/player/character_body.tscn" id="2_3ohbj"]
@@ -9,10 +9,6 @@ size = Vector3(1, 2, 0.5)
 
 [sub_resource type="BoxMesh" id="BoxMesh_rl4hs"]
 size = Vector3(1, 2, 0.5)
-
-[sub_resource type="BoxShape3D" id="BoxShape3D_unmdi"]
-custom_solver_bias = 0.95
-size = Vector3(1, 1.95, 0.5)
 
 [node name="Character" type="CharacterBody3D"]
 metadata/custom_overall_bounding_box = AABB(-0.5, -1, -0.25, 1, 2, 0.5)
@@ -34,41 +30,30 @@ skeleton = NodePath("../..")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.75, 0)
 
 [node name="BottomRayCollider1" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, 0)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.9, 0)
 shape = ExtResource("3_unmdi")
 disabled = true
 
 [node name="BottomRayCollider2" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, 0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.9, 0.26)
 shape = ExtResource("3_unmdi")
-disabled = true
 
 [node name="BottomRayCollider3" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, -0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.9, -0.26)
 shape = ExtResource("3_unmdi")
-disabled = true
 
 [node name="BottomRayCollider4" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.95, -0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.51, -0.9, -0.26)
 shape = ExtResource("3_unmdi")
-disabled = true
 
 [node name="BottomRayCollider5" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.95, -0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.51, -0.9, -0.26)
 shape = ExtResource("3_unmdi")
-disabled = true
 
 [node name="BottomRayCollider6" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.95, 0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.51, -0.9, 0.26)
 shape = ExtResource("3_unmdi")
-disabled = true
 
 [node name="BottomRayCollider7" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.95, 0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.51, -0.9, 0.26)
 shape = ExtResource("3_unmdi")
-disabled = true
-
-[node name="BoxCollider" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.025, 0)
-shape = SubResource("BoxShape3D_unmdi")
-disabled = true

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -12,7 +12,7 @@ size = Vector3(1, 2, 0.5)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_unmdi"]
 custom_solver_bias = 0.95
-size = Vector3(1, 1.9, 0.5)
+size = Vector3(1, 1.95, 0.5)
 
 [node name="Character" type="CharacterBody3D"]
 metadata/custom_overall_bounding_box = AABB(-0.5, -1, -0.25, 1, 2, 0.5)
@@ -35,33 +35,33 @@ skeleton = NodePath("../..")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.75, 0)
 
 [node name="BottomRayCollider1" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.9, 0)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, 0)
 shape = ExtResource("3_unmdi")
 
 [node name="BottomRayCollider2" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.9, 0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, 0.25)
 shape = ExtResource("3_unmdi")
 
 [node name="BottomRayCollider3" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.9, -0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, -0.25)
 shape = ExtResource("3_unmdi")
 
 [node name="BottomRayCollider4" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.9, -0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.95, -0.25)
 shape = ExtResource("3_unmdi")
 
 [node name="BottomRayCollider5" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.9, -0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.95, -0.25)
 shape = ExtResource("3_unmdi")
 
 [node name="BottomRayCollider6" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.9, 0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.95, 0.25)
 shape = ExtResource("3_unmdi")
 
 [node name="BottomRayCollider7" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.9, 0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.95, 0.25)
 shape = ExtResource("3_unmdi")
 
 [node name="BoxCollider" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.025, 0)
 shape = SubResource("BoxShape3D_unmdi")

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=6 format=3 uid="uid://bhraj4ym0cswa"]
+[gd_scene load_steps=7 format=3 uid="uid://bhraj4ym0cswa"]
 
 [ext_resource type="Material" uid="uid://bmtoyp50ewt6w" path="res://scenes/player/torso_texture.tres" id="1_8fnx3"]
 [ext_resource type="PackedScene" uid="uid://dx0npmluqx167" path="res://scenes/player/character_body.tscn" id="2_3ohbj"]
@@ -9,6 +9,10 @@ size = Vector3(1, 2, 0.5)
 
 [sub_resource type="BoxMesh" id="BoxMesh_rl4hs"]
 size = Vector3(1, 2, 0.5)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_unmdi"]
+custom_solver_bias = 0.95
+size = Vector3(1, 1.9, 0.5)
 
 [node name="Character" type="CharacterBody3D"]
 metadata/custom_overall_bounding_box = AABB(-0.5, -1, -0.25, 1, 2, 0.5)
@@ -57,3 +61,7 @@ shape = ExtResource("3_unmdi")
 [node name="BottomRayCollider7" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.9, 0.25)
 shape = ExtResource("3_unmdi")
+
+[node name="BoxCollider" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0)
+shape = SubResource("BoxShape3D_unmdi")

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -22,7 +22,6 @@ metadata/type = "OverallBoundingBoxObject"
 
 [node name="RootCollider" type="CollisionShape3D" parent="."]
 shape = SubResource("BoxShape3D_s2be1")
-disabled = true
 
 [node name="Mesh" type="MeshInstance3D" parent="RootCollider"]
 material_override = ExtResource("1_8fnx3")
@@ -37,31 +36,39 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.75, 0)
 [node name="BottomRayCollider1" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, 0)
 shape = ExtResource("3_unmdi")
+disabled = true
 
 [node name="BottomRayCollider2" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, 0.25)
 shape = ExtResource("3_unmdi")
+disabled = true
 
 [node name="BottomRayCollider3" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, -0.25)
 shape = ExtResource("3_unmdi")
+disabled = true
 
 [node name="BottomRayCollider4" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.95, -0.25)
 shape = ExtResource("3_unmdi")
+disabled = true
 
 [node name="BottomRayCollider5" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.95, -0.25)
 shape = ExtResource("3_unmdi")
+disabled = true
 
 [node name="BottomRayCollider6" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.95, 0.25)
 shape = ExtResource("3_unmdi")
+disabled = true
 
 [node name="BottomRayCollider7" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.95, 0.25)
 shape = ExtResource("3_unmdi")
+disabled = true
 
 [node name="BoxCollider" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.025, 0)
 shape = SubResource("BoxShape3D_unmdi")
+disabled = true

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=6 format=3 uid="uid://bhraj4ym0cswa"]
+[gd_scene load_steps=5 format=3 uid="uid://bhraj4ym0cswa"]
 
 [ext_resource type="Material" uid="uid://bmtoyp50ewt6w" path="res://scenes/player/torso_texture.tres" id="1_8fnx3"]
 [ext_resource type="PackedScene" uid="uid://dx0npmluqx167" path="res://scenes/player/character_body.tscn" id="2_3ohbj"]
-[ext_resource type="Shape3D" uid="uid://iu17a55w1yrj" path="res://scenes/player/collision_ray.tres" id="3_unmdi"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_s2be1"]
 size = Vector3(1, 2, 0.5)
@@ -28,32 +27,3 @@ skeleton = NodePath("../..")
 
 [node name="CameraFocus" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.75, 0)
-
-[node name="BottomRayCollider1" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.9, 0)
-shape = ExtResource("3_unmdi")
-disabled = true
-
-[node name="BottomRayCollider2" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.9, 0.26)
-shape = ExtResource("3_unmdi")
-
-[node name="BottomRayCollider3" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.9, -0.26)
-shape = ExtResource("3_unmdi")
-
-[node name="BottomRayCollider4" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.51, -0.9, -0.26)
-shape = ExtResource("3_unmdi")
-
-[node name="BottomRayCollider5" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.51, -0.9, -0.26)
-shape = ExtResource("3_unmdi")
-
-[node name="BottomRayCollider6" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.51, -0.9, 0.26)
-shape = ExtResource("3_unmdi")
-
-[node name="BottomRayCollider7" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.51, -0.9, 0.26)
-shape = ExtResource("3_unmdi")

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -2,16 +2,13 @@
 
 [ext_resource type="Material" uid="uid://bmtoyp50ewt6w" path="res://scenes/player/torso_texture.tres" id="1_8fnx3"]
 [ext_resource type="PackedScene" uid="uid://dx0npmluqx167" path="res://scenes/player/character_body.tscn" id="2_3ohbj"]
+[ext_resource type="Shape3D" uid="uid://iu17a55w1yrj" path="res://scenes/player/collision_ray.tres" id="3_unmdi"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_s2be1"]
 size = Vector3(1, 2, 0.5)
 
 [sub_resource type="BoxMesh" id="BoxMesh_rl4hs"]
 size = Vector3(1, 2, 0.5)
-
-[sub_resource type="SeparationRayShape3D" id="SeparationRayShape3D_ntlox"]
-length = 0.1
-slide_on_slope = true
 
 [node name="Character" type="CharacterBody3D"]
 metadata/custom_overall_bounding_box = AABB(-0.5, -1, -0.25, 1, 2, 0.5)
@@ -33,6 +30,30 @@ skeleton = NodePath("../..")
 [node name="CameraFocus" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.75, 0)
 
-[node name="BottomRayCollider" type="CollisionShape3D" parent="."]
+[node name="BottomRayCollider1" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, 0)
-shape = SubResource("SeparationRayShape3D_ntlox")
+shape = ExtResource("3_unmdi")
+
+[node name="BottomRayCollider2" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, 0.25)
+shape = ExtResource("3_unmdi")
+
+[node name="BottomRayCollider3" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, -0.25)
+shape = ExtResource("3_unmdi")
+
+[node name="BottomRayCollider4" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.95, -0.25)
+shape = ExtResource("3_unmdi")
+
+[node name="BottomRayCollider5" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.95, -0.25)
+shape = ExtResource("3_unmdi")
+
+[node name="BottomRayCollider6" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.95, 0.25)
+shape = ExtResource("3_unmdi")
+
+[node name="BottomRayCollider7" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.95, 0.25)
+shape = ExtResource("3_unmdi")

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -10,6 +10,7 @@ size = Vector3(1, 2, 0.5)
 size = Vector3(1, 2, 0.5)
 
 [sub_resource type="SeparationRayShape3D" id="SeparationRayShape3D_ntlox"]
+length = 0.1
 slide_on_slope = true
 
 [node name="Character" type="CharacterBody3D"]
@@ -33,5 +34,5 @@ skeleton = NodePath("../..")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.75, 0)
 
 [node name="RayCollider" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, 0)
 shape = SubResource("SeparationRayShape3D_ntlox")

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -10,6 +10,7 @@ size = Vector3(1, 2, 0.5)
 size = Vector3(1, 2, 0.5)
 
 [node name="Character" type="CharacterBody3D"]
+floor_max_angle = 1.309
 metadata/custom_overall_bounding_box = AABB(-0.5, -1, -0.25, 1, 2, 0.5)
 
 [node name="_InteractiveBoundingBox" type="Node" parent="."]

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -10,7 +10,6 @@ size = Vector3(1, 2, 0.5)
 size = Vector3(1, 2, 0.5)
 
 [sub_resource type="SeparationRayShape3D" id="SeparationRayShape3D_ntlox"]
-length = 2.0
 slide_on_slope = true
 
 [node name="Character" type="CharacterBody3D"]

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -33,6 +33,6 @@ skeleton = NodePath("../..")
 [node name="CameraFocus" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.75, 0)
 
-[node name="RaycastCollider" type="CollisionShape3D" parent="."]
+[node name="RayCollider" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0)
 shape = SubResource("SeparationRayShape3D_ntlox")

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -31,29 +31,29 @@ skeleton = NodePath("../..")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.75, 0)
 
 [node name="BottomRayCollider1" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, 0)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.9, 0)
 shape = ExtResource("3_unmdi")
 
 [node name="BottomRayCollider2" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, 0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.9, 0.25)
 shape = ExtResource("3_unmdi")
 
 [node name="BottomRayCollider3" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, -0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.9, -0.25)
 shape = ExtResource("3_unmdi")
 
 [node name="BottomRayCollider4" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.95, -0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.9, -0.25)
 shape = ExtResource("3_unmdi")
 
 [node name="BottomRayCollider5" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.95, -0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.9, -0.25)
 shape = ExtResource("3_unmdi")
 
 [node name="BottomRayCollider6" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.95, 0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.9, 0.25)
 shape = ExtResource("3_unmdi")
 
 [node name="BottomRayCollider7" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.95, 0.25)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.9, 0.25)
 shape = ExtResource("3_unmdi")

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://bhraj4ym0cswa"]
+[gd_scene load_steps=6 format=3 uid="uid://bhraj4ym0cswa"]
 
 [ext_resource type="Material" uid="uid://bmtoyp50ewt6w" path="res://scenes/player/torso_texture.tres" id="1_8fnx3"]
 [ext_resource type="PackedScene" uid="uid://dx0npmluqx167" path="res://scenes/player/character_body.tscn" id="2_3ohbj"]
@@ -9,6 +9,10 @@ size = Vector3(1, 2, 0.5)
 [sub_resource type="BoxMesh" id="BoxMesh_rl4hs"]
 size = Vector3(1, 2, 0.5)
 
+[sub_resource type="SeparationRayShape3D" id="SeparationRayShape3D_ntlox"]
+length = 2.0
+slide_on_slope = true
+
 [node name="Character" type="CharacterBody3D"]
 metadata/custom_overall_bounding_box = AABB(-0.5, -1, -0.25, 1, 2, 0.5)
 
@@ -17,6 +21,7 @@ metadata/type = "OverallBoundingBoxObject"
 
 [node name="RootCollider" type="CollisionShape3D" parent="."]
 shape = SubResource("BoxShape3D_s2be1")
+disabled = true
 
 [node name="Mesh" type="MeshInstance3D" parent="RootCollider"]
 material_override = ExtResource("1_8fnx3")
@@ -27,3 +32,7 @@ skeleton = NodePath("../..")
 
 [node name="CameraFocus" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.75, 0)
+
+[node name="RaycastCollider" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0)
+shape = SubResource("SeparationRayShape3D_ntlox")

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -33,6 +33,6 @@ skeleton = NodePath("../..")
 [node name="CameraFocus" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.75, 0)
 
-[node name="RayCollider" type="CollisionShape3D" parent="."]
+[node name="BottomRayCollider" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.95, 0)
 shape = SubResource("SeparationRayShape3D_ntlox")

--- a/scenes/player/collision_ray.tres
+++ b/scenes/player/collision_ray.tres
@@ -1,0 +1,5 @@
+[gd_resource type="SeparationRayShape3D" format=3 uid="uid://iu17a55w1yrj"]
+
+[resource]
+length = 0.1
+slide_on_slope = true

--- a/scenes/player/collision_ray.tres
+++ b/scenes/player/collision_ray.tres
@@ -1,5 +1,5 @@
 [gd_resource type="SeparationRayShape3D" format=3 uid="uid://iu17a55w1yrj"]
 
 [resource]
-length = 0.1
+length = 0.05
 slide_on_slope = true

--- a/scenes/player/collision_ray.tres
+++ b/scenes/player/collision_ray.tres
@@ -1,5 +1,5 @@
 [gd_resource type="SeparationRayShape3D" format=3 uid="uid://iu17a55w1yrj"]
 
 [resource]
-length = 0.05
+length = 0.1
 slide_on_slope = true

--- a/src/app/JumpvalleyPlayer.cs
+++ b/src/app/JumpvalleyPlayer.cs
@@ -123,7 +123,7 @@ namespace UTheCat.Jumpvalley.App
             Mover.AirAcceleration = 180f; //90f;
             Mover.Deceleration = 360f; //180f;
             Mover.AirDeceleration = 180f; //90f;
-            Mover.Rotator.Speed = 10f;
+            Mover.Rotator.Speed = 12f;
 
             Mover.Body = Character;
 

--- a/src/app/JumpvalleyPlayer.cs
+++ b/src/app/JumpvalleyPlayer.cs
@@ -119,10 +119,11 @@ namespace UTheCat.Jumpvalley.App
             Mover.Gravity = PhysicsServer3D.AreaGetParam(RootNode.GetViewport().FindWorld3D().Space, PhysicsServer3D.AreaParameter.Gravity).As<float>();
             Mover.JumpVelocity = 25f;
             Mover.Speed = 8f;
-            Mover.Acceleration = 180f;
-            Mover.AirAcceleration = 90f;
-            Mover.Deceleration = 180f;
-            Mover.AirDeceleration = 90f;
+            Mover.Acceleration = 360f; //180f;
+            Mover.AirAcceleration = 180f; //90f;
+            Mover.Deceleration = 360f; //180f;
+            Mover.AirDeceleration = 180f; //90f;
+            Mover.Rotator.Speed = 10f;
 
             Mover.Body = Character;
 

--- a/src/app/JumpvalleyPlayer.cs
+++ b/src/app/JumpvalleyPlayer.cs
@@ -119,10 +119,10 @@ namespace UTheCat.Jumpvalley.App
             Mover.Gravity = PhysicsServer3D.AreaGetParam(RootNode.GetViewport().FindWorld3D().Space, PhysicsServer3D.AreaParameter.Gravity).As<float>();
             Mover.JumpVelocity = 25f;
             Mover.Speed = 8f;
-            Mover.Acceleration = 360f; //180f;
-            Mover.AirAcceleration = 180f; //90f;
-            Mover.Deceleration = 360f; //180f;
-            Mover.AirDeceleration = 180f; //90f;
+            Mover.Acceleration = 180f;
+            Mover.AirAcceleration = 90f;
+            Mover.Deceleration = 180f;
+            Mover.AirDeceleration = 90f;
             Mover.Rotator.Speed = 12f;
 
             Mover.Body = Character;

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -345,7 +345,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// <summary>
         /// The forces to apply when <see cref="HandlePhysicsStep"/> is called.
         /// The order in which the forces in this list are applied is from the end of the list to the beginning of the list.
-        /// This list is cleared when <see cref="HandlePhysicsStep"/> is called. 
+        /// This list is cleared when <see cref="HandlePhysicsStep"/> is called.
         /// <br/><br/>
         /// Forces are in newtons.
         /// </summary>

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -396,6 +396,11 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             return false;
         }
 
+        private Vector3 GetUpDirection()
+        {
+            return Body == null ? Vector3.Up : Body.UpDirection;
+        }
+
         /// <summary>
         /// Calculates and returns the move vector that the player wants to move the character in, regardless of whether or not they're currently jumping or climbing.
         /// <br/>
@@ -403,7 +408,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// </summary>
         /// <param name="yaw">The yaw angle that the forward and right values are relative to.</param>
         /// <returns>The calculated move vector</returns>
-        public Vector3 GetMoveVector(float yaw)
+        public Vector3 GetMoveDirection(float yaw)
         {
             // The Rotate() call rotates the MoveVector to the specified yaw angle.
             return new Vector3(RightValue, 0, ForwardValue).Rotated(Vector3.Up, yaw).Normalized();
@@ -427,14 +432,17 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// <summary>
         /// Gets the target horizontal velocity (velocity along the X and Z axes) that the character is trying to move at for the current physics frame.
         /// <br/><br/>
-        /// This function takes physics framerate and acceleration into account.
+        /// This function takes physics framerate, acceleration, and target move direction into account.
         /// </summary>
+        /// <param name="physicsFrameDelta">The time it took to complete the most recent physics frame.</param>
+        /// <param name="acceleration">The time it took to complete the most recent physics frame.</param>
+        /// <param name="yaw">The intended move direction to </param> 
         /// <returns>
         /// The target horizontal velocity as a Vector3. This Vector3 is in global coordinates.
         /// </returns>
-        private Vector3 GetHorizontalVelocity(float physicsFrameDelta, float acceleration)
+        private Vector3 GetHorizontalVelocity(float physicsFrameDelta, float acceleration, float yaw)
         {
-            Vector3 upDirection = Body == null ? Vector3.Up : Body.UpDirection;
+            Vector3 moveDirection = GetMoveDirection(yaw);
 
             return Vector3.Zero;
         }
@@ -455,7 +463,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
 
             bool isOnFloor = IsOnFloor();
 
-            Vector3 moveVector = GetMoveVector(yaw);
+            Vector3 moveVector = GetMoveDirection(yaw);
             Vector3 velocity;
 
             if (Body == null)

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -822,7 +822,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                     requestedVelocityAfterMove.Z
                     );
 
-                // Push objects we've come into contact with.
+                // Figure out how to push objects we've come into contact with.
                 // Thanks to this forum post for helping me figure out how to implement this:
                 // https://forum.godotengine.org/t/how-to-fix-movable-box-physics/75853
                 Dictionary<RigidBody3D, RigidBodyPusher> rigidBodyPushers = [];
@@ -857,6 +857,9 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                         }
                     }
                 }
+
+                // Do the actual RigidBody3D pushing.
+                foreach (RigidBodyPusher pusher in rigidBodyPushers.Values) pusher.Push();
 
                 if (IsJumping && realVelocity.Y > 0)
                 {

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -693,27 +693,39 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             return finalVelocity;
         }
         
+        /// <summary>
+        /// This nested class is intended to smooth pushing RigidBody3Ds.
+        /// <br/><br/>
+        /// When Godot thinks the character is colliding with the RigidBody3D at multiple spots in the same physics frame,
+        /// pushing the RigidBody3D in the right direction can be RNG.
+        /// <br/><br/>
+        /// Therefore, this class was made to assist with making a push in a valid position that's as close to
+        /// the rigid body's center of mass as possible.
+        /// </summary>
         class RigidBodyPusher
         {
             public RigidBody3D Body = null;
 
             /// <summary>
-            /// Position offsets from the origin of <see cref="Body"/> in global coordinates.
-            /// This list is used to average out the position in which we apply force on <see cref="Body"/>. 
+            /// Position offset from <see cref="Body"/>'s origin in global coordinates. 
             /// </summary>
-            public List<Vector3> Offsets = new List<Vector3>();
+            private Vector3 positionOffset = Vector3.Zero;
 
             public Vector3 PushDirection = Vector3.Zero;
 
             public float PushForce = 0.0f;
+
+            public void SetPositionOffsetIfCloser(Vector3 offset)
+            {
+                if (Body == null) return;
+
+                Vector3 centerOfMass = Body.CenterOfMass;
+                if ((offset - centerOfMass).Length() < (positionOffset - centerOfMass).Length()) positionOffset = offset;
+            }
             
             public void Push()
             {
-                Vector3 avgPosition = new Vector3();
-                foreach (Vector3 v in Offsets) avgPosition += v;
-                avgPosition /= Offsets.Count;
-
-                Body.ApplyForce(PushDirection * PushForce, avgPosition);
+                Body.ApplyForce(PushDirection * PushForce, positionOffset);
             }
         }
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -788,11 +788,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 //
                 // We store the character's real Y velocity to prevent the character from "building up" downwards velocity
                 // when the character is not moving when IsOnFloor() returns false.
-                LastVelocity = new Vector3(
-                    finalVelocity.X,
-                    realVelocity.Y,
-                    finalVelocity.Z
-                    );
+                LastVelocity = new Vector3(finalVelocity.X, realVelocity.Y, finalVelocity.Z);         
 
                 if (IsJumping && realVelocity.Y > 0)
                 {

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -343,7 +343,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// <summary>
         /// The mass of the character in kilograms.
         /// </summary>
-        public float Mass = 5f;
+        public float Mass = 50f;
 
         //private ConsoleLogger logger;
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -427,12 +427,12 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// <summary>
         /// Gets the target horizontal velocity (velocity along the X and Z axes) that the character is trying to move at for the current physics frame.
         /// <br/><br/>
-        /// This function is independent of current physics framerate and acceleration/decceleration.
+        /// This function takes physics framerate and acceleration into account.
         /// </summary>
         /// <returns>
         /// The target horizontal velocity as a Vector3. This Vector3 is in global coordinates.
         /// </returns>
-        public Vector3 GetTargetHorizontalVelocity()
+        private Vector3 GetHorizontalVelocity(float physicsFrameDelta, float acceleration)
         {
             Vector3 upDirection = Body == null ? Vector3.Up : Body.UpDirection;
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -799,7 +799,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                     if (collision.GetCollider() is RigidBody3D rigidBody)
                     {
                         Vector3 collisionNormal = collision.GetNormal();
-                        rigidBody.ApplyForce(collisionNormal * -(Mass * acceleration * fDelta), rigidBody.GlobalPosition - collision.GetPosition() + collisionNormal * collision.GetDepth());
+                        rigidBody.ApplyForce(collisionNormal * -(Mass * acceleration * fDelta), collision.GetPosition() - rigidBody.GlobalPosition + collisionNormal * collision.GetDepth());
                     }
                 }
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -784,9 +784,13 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
 
                 // Store the current velocity for the next physics frame to use.
                 //
-                // We store the character's real Y velocity to prevent the character from "building up" downwards velocity
+                // We store the character's real Y velocity if it's close enough to 0 to prevent the character from "building up" downwards velocity
                 // when the character is not moving when IsOnFloor() returns false.
-                LastVelocity = new Vector3(finalVelocity.X, realVelocity.Y, finalVelocity.Z);
+                LastVelocity = new Vector3(
+                    finalVelocity.X,
+                    Mathf.IsZeroApprox(realVelocity.Y) ? 0f : finalVelocity.Y,
+                    finalVelocity.Z
+                    );
 
                 if (IsJumping && realVelocity.Y > 0)
                 {

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -780,14 +780,15 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
 
                 //logger.Print($"Current velocity: {lastVelocity} | Velocity after MoveAndSlide: {body.Velocity}");
 
-                // update CurrentBodyState according to the character's actual velocity and the values of IsJumping and IsClimbing
-                Vector3 actualVelocity = body.GetRealVelocity();
+                Vector3 realVelocity = body.GetRealVelocity();
 
-                // To keep things smooth, we want to store the character velocity for this physics frame
-                // after MoveAndSlide() has modified the velocity
-                LastVelocity = actualVelocity;
+                // Store the current velocity for the next physics frame to use.
+                //
+                // We store the character's real Y velocity to prevent the character from "building up" downwards velocity
+                // when the character is not moving when IsOnFloor() returns false.
+                LastVelocity = new Vector3(finalVelocity.X, realVelocity.Y, finalVelocity.Z);
 
-                if (IsJumping && actualVelocity.Y > 0)
+                if (IsJumping && realVelocity.Y > 0)
                 {
                     // Jumping is placed first in line so that jumping can affect climbing
                     CurrentBodyState = BodyState.Jumping;
@@ -796,15 +797,15 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 {
                     CurrentBodyState = BodyState.Climbing;
                 }
-                else if (IsJumping == false && actualVelocity.Y > 0)
+                else if (IsJumping == false && realVelocity.Y > 0)
                 {
                     CurrentBodyState = BodyState.Rising;
                 }
-                else if (actualVelocity.Y < 0)
+                else if (realVelocity.Y < 0)
                 {
                     CurrentBodyState = BodyState.Falling;
                 }
-                else if ((actualVelocity.X != 0 || actualVelocity.Z != 0) && IsOnFloor())
+                else if ((realVelocity.X != 0 || realVelocity.Z != 0) && IsOnFloor())
                 {
                     if (RightValue != 0 || ForwardValue != 0)
                     {

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -438,7 +438,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// </summary>
         /// <param name="physicsFrameDelta">The time it took to complete the most recent physics frame.</param>
         /// <param name="acceleration">Vector3 specifying current acceleration, with Vector3.</param>
-        /// <param name="yaw">The intended move direction to </param> 
+        /// <param name="yaw">The intended move 'yaw'. For example, this yaw could be the yaw of the player's camera.</param> 
         /// <returns>
         /// The updated horizontal velocity.
         /// </returns>

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -345,7 +345,6 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// <summary>
         /// The forces to apply when <see cref="HandlePhysicsStep"/> is called.
         /// The order in which the forces in this list are applied is from the end of the list to the beginning of the list.
-        /// This list is cleared when <see cref="HandlePhysicsStep"/> is called.
         /// <br/><br/>
         /// Forces are in newtons.
         /// </summary>

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -335,8 +335,10 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// The order in which the forces in this list are applied is from the end of the list to the beginning of the list.
         /// <br/><br/>
         /// Forces are in newtons.
+        /// <br/><br/>
+        /// To be implemented.
         /// </summary>
-        public List<Vector3> ForceQueue = new List<Vector3>();
+        //public List<Vector3> ForceQueue = new List<Vector3>();
 
         /// <summary>
         /// The mass of the character in kilograms.

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -343,7 +343,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// <summary>
         /// The mass of the character in kilograms.
         /// </summary>
-        public float Mass = 50f;
+        public float Mass = 60f;
 
         //private ConsoleLogger logger;
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -698,17 +698,14 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             public RigidBody3D Body = null;
 
             /// <summary>
-            /// Calculated for each physics frame in <see cref="HandlePhysicsStep"/>. 
-            /// </summary>
-            public static float CurrentPhysicsFrameForce = 0.0f;
-
-            /// <summary>
             /// Position offsets from the origin of <see cref="Body"/> in global coordinates.
             /// This list is used to average out the position in which we apply force on <see cref="Body"/>. 
             /// </summary>
             public List<Vector3> Offsets = new List<Vector3>();
 
             public Vector3 PushDirection = Vector3.Zero;
+
+            public float PushForce = 0.0f;
             
             public void Push()
             {
@@ -716,7 +713,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 foreach (Vector3 v in Offsets) avgPosition += v;
                 avgPosition /= Offsets.Count;
 
-                Body.ApplyForce(PushDirection * CurrentPhysicsFrameForce, avgPosition);
+                Body.ApplyForce(PushDirection * PushForce, avgPosition);
             }
         }
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -347,6 +347,8 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
 
         //private ConsoleLogger logger;
 
+        private Vector2 lastHorizontalVelocity = Vector2.Zero;
+
         /// <summary>
         /// Constructs a new instance of BaseMover that can be used to handle character movement
         /// </summary>
@@ -430,21 +432,30 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         }
 
         /// <summary>
-        /// Gets the target horizontal velocity (velocity along the X and Z axes) that the character is trying to move at for the current physics frame.
+        /// Updates horizontal velocity (velocity along the X and Z axes) that the character is trying to move at for the current physics frame.
         /// <br/><br/>
         /// This function takes physics framerate, acceleration, and target move direction into account.
         /// </summary>
         /// <param name="physicsFrameDelta">The time it took to complete the most recent physics frame.</param>
-        /// <param name="acceleration">The time it took to complete the most recent physics frame.</param>
+        /// <param name="acceleration">Vector3 specifying current acceleration, with Vector3.</param>
         /// <param name="yaw">The intended move direction to </param> 
         /// <returns>
-        /// The target horizontal velocity as a Vector3. This Vector3 is in global coordinates.
+        /// The updated horizontal velocity.
         /// </returns>
-        private Vector3 GetHorizontalVelocity(float physicsFrameDelta, float acceleration, float yaw)
+        private Vector2 UpdateHorizontalVelocity(float physicsFrameDelta, float acceleration, float yaw)
         {
             Vector3 moveDirection = GetMoveDirection(yaw);
 
-            return Vector3.Zero;
+            // For the goalXZVelocity Vector2, Y-coordinate is the goal velocity's Z coordinate.
+            Vector2 newHorizontalVelocity = ApproachXZVelocity(
+                lastHorizontalVelocity,
+                new Vector2(moveDirection.X, moveDirection.Z),
+                acceleration,
+                physicsFrameDelta
+            );
+            lastHorizontalVelocity = newHorizontalVelocity;
+
+            return newHorizontalVelocity;
         }
 
         /// <summary>

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -700,7 +700,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             /// <summary>
             /// Calculated for each physics frame in <see cref="HandlePhysicsStep"/>. 
             /// </summary>
-            private float currentPhysicsFrameForce = 0.0f;
+            public static float CurrentPhysicsFrameForce = 0.0f;
 
             /// <summary>
             /// Position offsets from the origin of <see cref="Body"/> in global coordinates.
@@ -716,7 +716,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 foreach (Vector3 v in Offsets) avgPosition += v;
                 avgPosition /= Offsets.Count;
 
-                Body.ApplyForce(PushDirection * currentPhysicsFrameForce, avgPosition);
+                Body.ApplyForce(PushDirection * CurrentPhysicsFrameForce, avgPosition);
             }
         }
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -786,10 +786,16 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
 
                 // Store the current velocity for the next physics frame to use.
                 //
-                // We store the character's real Y velocity to prevent the character from "building up" downwards velocity
-                // when the character is not moving when IsOnFloor() returns false.
+                // If the character's real Y-velocity after MoveAndSlide is less than the requested velocity after MoveAndSlide,
+                // we use the real Y-velocity.
+                // This is mainly to prevent the character from building up downwards velocity when IsOnFloor() returns false but the character
+                // is not moving downward.
                 Vector3 requestedVelocityAfterMove = body.Velocity;
-                LastVelocity = new Vector3(requestedVelocityAfterMove.X, realVelocity.Y, requestedVelocityAfterMove.Z);
+                LastVelocity = new Vector3(
+                    requestedVelocityAfterMove.X,
+                    Math.Abs(realVelocity.Y) < Math.Abs(requestedVelocityAfterMove.Y) ? realVelocity.Y : requestedVelocityAfterMove.Y,
+                    requestedVelocityAfterMove.Z
+                    );
 
                 // Push objects we've come into contact with.
                 // Thanks to this forum post for helping me figure out how to implement this:

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -343,8 +343,9 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         private ShapeCast3D climbingShapeCast;
 
         /// <summary>
-        /// The forces to apply before the next physics update.
+        /// The forces to apply when <see cref="HandlePhysicsStep"/> is called.
         /// The order in which the forces in this list are applied is from the end of the list to the beginning of the list.
+        /// This list is cleared when <see cref="HandlePhysicsStep"/> is called. 
         /// <br/><br/>
         /// Forces are in newtons.
         /// </summary>

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -788,7 +788,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 //
                 // We store the character's real Y velocity to prevent the character from "building up" downwards velocity
                 // when the character is not moving when IsOnFloor() returns false.
-                LastVelocity = new Vector3(finalVelocity.X, realVelocity.Y, finalVelocity.Z);         
+                LastVelocity = new Vector3(finalVelocity.X, realVelocity.Y, finalVelocity.Z);
 
                 if (IsJumping && realVelocity.Y > 0)
                 {

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -784,11 +784,11 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
 
                 // Store the current velocity for the next physics frame to use.
                 //
-                // We store the character's real Y velocity if it's close enough to 0 to prevent the character from "building up" downwards velocity
+                // We store the character's real Y velocity to prevent the character from "building up" downwards velocity
                 // when the character is not moving when IsOnFloor() returns false.
                 LastVelocity = new Vector3(
                     finalVelocity.X,
-                    Mathf.IsZeroApprox(realVelocity.Y) ? 0f : finalVelocity.Y,
+                    realVelocity.Y,
                     finalVelocity.Z
                     );
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -350,6 +350,11 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// </summary>
         public List<Vector3> ForceQueue = new List<Vector3>();
 
+        /// <summary>
+        /// The mass of the character in kilograms.
+        /// </summary>
+        public float Mass = 5f;
+
         //private ConsoleLogger logger;
 
         /// <summary>

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -796,7 +796,8 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                     KinematicCollision3D collision = body.GetSlideCollision(i);
                     if (collision.GetCollider() is RigidBody3D rigidBody)
                     {
-                        rigidBody.ApplyForce(collision.GetNormal() * -(Mass * acceleration * fDelta));
+                        Vector3 collisionNormal = collision.GetNormal();
+                        rigidBody.ApplyForce(collisionNormal * -(Mass * acceleration * fDelta), rigidBody.GlobalPosition - collision.GetPosition() + collisionNormal * collision.GetDepth());
                     }
                 }
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -788,7 +788,8 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 //
                 // We store the character's real Y velocity to prevent the character from "building up" downwards velocity
                 // when the character is not moving when IsOnFloor() returns false.
-                LastVelocity = new Vector3(finalVelocity.X, realVelocity.Y, finalVelocity.Z);
+                Vector3 requestedVelocityAfterMove = body.Velocity;
+                LastVelocity = new Vector3(requestedVelocityAfterMove.X, realVelocity.Y, requestedVelocityAfterMove.Z);
 
                 // Push objects we've come into contact with.
                 // Thanks to this forum post for helping me figure out how to implement this:

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -790,6 +790,16 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 // when the character is not moving when IsOnFloor() returns false.
                 LastVelocity = new Vector3(finalVelocity.X, realVelocity.Y, finalVelocity.Z);
 
+                // Push objects we've come into contact with.
+                for (int i = 0; i < body.GetSlideCollisionCount(); i++)
+                {
+                    KinematicCollision3D collision = body.GetSlideCollision(i);
+                    if (collision.GetCollider() is RigidBody3D rigidBody)
+                    {
+                        rigidBody.ApplyForce(collision.GetNormal() * -(Mass * acceleration * fDelta));
+                    }
+                }
+
                 if (IsJumping && realVelocity.Y > 0)
                 {
                     // Jumping is placed first in line so that jumping can affect climbing

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -425,6 +425,21 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         }
 
         /// <summary>
+        /// Gets the target horizontal velocity (velocity along the X and Z axes) that the character is trying to move at for the current physics frame.
+        /// <br/><br/>
+        /// This function is independent of current physics framerate and acceleration/decceleration.
+        /// </summary>
+        /// <returns>
+        /// The target horizontal velocity as a Vector3. This Vector3 is in global coordinates.
+        /// </returns>
+        public Vector3 GetTargetHorizontalVelocity()
+        {
+            Vector3 upDirection = Body == null ? Vector3.Up : Body.UpDirection;
+
+            return Vector3.Zero;
+        }
+
+        /// <summary>
         /// Gets the velocity that the character wants to move at for the current physics frame
         /// </summary>
         /// <param name="delta">The time it took to complete the physics frame in seconds</param>

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -1,7 +1,5 @@
 ﻿using Godot;
-using UTheCat.Jumpvalley.Core.Logging;
 using UTheCat.Jumpvalley.Core.Players.Camera;
-using UTheCat.Jumpvalley.Core.Raycasting;
 using System;
 using System.Collections.Generic;
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -826,16 +826,17 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 // Push objects we've come into contact with.
                 // Thanks to this forum post for helping me figure out how to implement this:
                 // https://forum.godotengine.org/t/how-to-fix-movable-box-physics/75853
-                RigidBody3D debugLastRigidBody = null;
+                List<RigidBody3D> collidedRigidBodies = [];
                 for (int i = 0; i < body.GetSlideCollisionCount(); i++)
                 {
                     KinematicCollision3D collision = body.GetSlideCollision(i);
                     if (collision.GetCollider() is RigidBody3D rigidBody)
                     {
-                        if (debugLastRigidBody == rigidBody) Console.WriteLine($"Collided with RigidBody3D named '{rigidBody.Name}' more than once in the same physics frame.");
-                        debugLastRigidBody = rigidBody;
+                        // Ensure the character only pushes the RigidBody3D up to once per physics frame
+                        if (collidedRigidBodies.Contains(rigidBody)) continue;
 
-                        Console.WriteLine($"Number of collisions for this KinematicCollision3D: {collision.GetCollisionCount()}");
+                        collidedRigidBodies.Add(rigidBody);
+
                         Vector3 collisionNormal = collision.GetNormal();
                         rigidBody.ApplyForce(collisionNormal * -(Mass * acceleration * fDelta), collision.GetPosition() - rigidBody.GlobalPosition + collisionNormal * collision.GetDepth());
                     }

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -786,10 +786,12 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
 
                 // Store the current velocity for the next physics frame to use.
                 //
-                // If the character's real Y-velocity after MoveAndSlide is less than the requested velocity after MoveAndSlide,
-                // we use the real Y-velocity.
-                // This is mainly to prevent the character from building up downwards velocity when IsOnFloor() returns false but the character
-                // is not moving downward.
+                // When updating LastVelocity, for the Y value, between real velocity after MoveAndSlide and requested velocity after move and slide,
+                // use whichever one is closest to 0.
+                // This is mainly to *prevent* these two issues:
+                // - Character builds up downwards velocity when IsOnFloor() returns false but the character
+                //   is not moving downward.
+                // - Character suddenly and unexpectedly jolts upward at a high velocity.
                 Vector3 requestedVelocityAfterMove = body.Velocity;
                 LastVelocity = new Vector3(
                     requestedVelocityAfterMove.X,

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -791,6 +791,8 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 LastVelocity = new Vector3(finalVelocity.X, realVelocity.Y, finalVelocity.Z);
 
                 // Push objects we've come into contact with.
+                // Thanks to this forum post for helping me figure out how to implement this:
+                // https://forum.godotengine.org/t/how-to-fix-movable-box-physics/75853
                 for (int i = 0; i < body.GetSlideCollisionCount(); i++)
                 {
                     KinematicCollision3D collision = body.GetSlideCollision(i);

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -861,6 +861,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 // Do the actual RigidBody3D pushing.
                 foreach (RigidBodyPusher pusher in rigidBodyPushers.Values) pusher.Push();
 
+                // Update current body state.
                 if (IsJumping && realVelocity.Y > 0)
                 {
                     // Jumping is placed first in line so that jumping can affect climbing

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -343,7 +343,10 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         private ShapeCast3D climbingShapeCast;
 
         /// <summary>
-        /// Queue of 3D forces in Newtons. Forces that are closer to the beginning of the list have greater priority.
+        /// The forces to apply before the next physics update.
+        /// The order in which the forces in this list are applied is from the end of the list to the beginning of the list.
+        /// <br/><br/>
+        /// Forces are in newtons.
         /// </summary>
         public List<Vector3> ForceQueue = new List<Vector3>();
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -155,19 +155,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// <summary>
         /// How fast the character can move in meters per second
         /// </summary>
-        public float Speed
-        {
-            get => _speed;
-            set
-            {
-                _speed = value;
-
-                if (Rotator != null)
-                {
-                    Rotator.Speed = value;
-                }
-            }
-        }
+        public float Speed = 5f;
 
         /// <summary>
         /// The current yaw angle of the camera that's currently associated with the character


### PR DESCRIPTION
Large pull request intended to iron out some issues and bring some needed features to character movement in Jumpvalley.

TO-DO
- [x] make it so "lodging" your character between 2 platforms while character isn't on floor won't make character build up down velocity
- [x] allow character to climb steeper slopes (up to 75 degrees)
- [ ] make character physics less time-dependent (where time-dependent refers to being affected by the amount of time taken to complete each physics frame)
- [ ] add dedicated area for experimenting with physics interactions between character and RigidBody3Ds
- [ ] allow character to push RigidBody3Ds. This should only happen when (character mass) > (RigidBody3D mass)
- [ ] allow character to be pushed *by* RigidBody3Ds. This should only happen when (character mass) < (RigidBody3D mass)