### PR TITLE
Switch back to Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ While there are precompiled versions of Jumpvalley for Android, Android support 
 
 ### For Linux users
 
+#### Allowing the system to run Jumpvalley
+
 The Jumpvalley executable for the Linux version of Jumpvalley is named `jumpvalley` (with no file extension).
 
 On Linux, the operating system itself controls whether or not a file can be executed, regardless of the file's file extension. Therefore, your copy of the Jumpvalley executable for Linux might not be marked as executable.
@@ -55,6 +57,12 @@ and type this command:
 `chmod +x jumpvalley`
 
 Assuming you did this correctly, this tells Linux to allow running the Jumpvalley executable.
+
+#### Wayland by Default
+
+Jumpvalley uses Wayland by default. If you need the app to run on X11 instead, then in the directory where the Jumpvalley executable is located, run this command:
+
+`./jumpvalley --display-driver x11`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ and type this command:
 
 Assuming you did this correctly, this tells Linux to allow running the Jumpvalley executable.
 
-#### Wayland by Default
+#### Wayland and X11
 
 Jumpvalley uses Wayland by default. If you need the app to run on X11 instead, then in the directory where the Jumpvalley executable is located, run this command:
 

--- a/project.godot
+++ b/project.godot
@@ -28,6 +28,7 @@ window/size/viewport_height=1080
 window/size/window_width_override=1152
 window/size/window_height_override=648
 window/stretch/aspect="expand"
+display_server/driver.linuxbsd="wayland"
 window/vsync/vsync_mode=0
 
 [dotnet]


### PR DESCRIPTION
Wayland seems to offer better performance than X11. For example, this screenshot was taken with Jumpvalley using Wayland on KDE Plasma (also on Wayland):

![Screenshot_20250519_195146_cropped](https://github.com/user-attachments/assets/54e83f9b-d80b-442f-8d5e-0ff2f04070ea)

This PR also updates the README to have instructions on how to run Jumpvalley using X11.