### PR TITLE
Use all doubles for method tween

### DIFF
--- a/src/app/Gui/BottomBar.cs
+++ b/src/app/Gui/BottomBar.cs
@@ -127,7 +127,7 @@ namespace UTheCat.Jumpvalley.App.Gui
             DescriptionOpacityTween.Tree = actualNodeTree;
             DescriptionOpacityTween.InitialValue = 0;
             DescriptionOpacityTween.FinalValue = 1;
-            DescriptionOpacityTween.OnStep += (object o, float frac) =>
+            DescriptionOpacityTween.OnStep += (object o, double _frac) =>
             {
                 float opacity = (float)DescriptionOpacityTween.GetCurrentValue();
 

--- a/src/app/Gui/FramerateCounter.cs
+++ b/src/app/Gui/FramerateCounter.cs
@@ -78,7 +78,7 @@ namespace UTheCat.Jumpvalley.App.Gui
                     FinalValue = 1.0,
                     Speed = 1f
                 };
-                opacityTween.OnStep += (object _o, float frac) =>
+                opacityTween.OnStep += (object _o, double _frac) =>
                 {
                     float opacity = (float)opacityTween.GetCurrentValue();
                     gui.Visible = opacity > 0;

--- a/src/app/Gui/LevelMenu.cs
+++ b/src/app/Gui/LevelMenu.cs
@@ -101,11 +101,11 @@ namespace UTheCat.Jumpvalley.App.Gui
             transparencyTween = new SceneTreeTween(0.25, Tween.TransitionType.Linear, Tween.EaseType.Out, tree);
             transparencyTween.InitialValue = 0;
             transparencyTween.FinalValue = 1;
-            transparencyTween.OnStep += (object o, float frac) =>
+            transparencyTween.OnStep += (object o, double frac) =>
             {
-                actualNode.Visible = frac > 0;
+                actualNode.Visible = frac > 0.0;
                 Color modulate = actualNode.Modulate;
-                modulate.A = frac;
+                modulate.A = (float)frac;
                 actualNode.Modulate = modulate;
             };
 
@@ -114,7 +114,7 @@ namespace UTheCat.Jumpvalley.App.Gui
                 backgroundSizeTween = new SceneTreeTween(0.5, Tween.TransitionType.Quad, Tween.EaseType.Out, tree);
                 backgroundSizeTween.InitialValue = 40;
                 backgroundSizeTween.FinalValue = 0;
-                backgroundSizeTween.OnStep += (object o, float frac) =>
+                backgroundSizeTween.OnStep += (object o, double _frac) =>
                 {
                     float sizeOffset = (float)(backgroundSizeTween.GetCurrentValue() * 0.5);
                     BackgroundControl.OffsetLeft = sizeOffset;

--- a/src/app/Gui/SettingsMenu.cs
+++ b/src/app/Gui/SettingsMenu.cs
@@ -69,7 +69,7 @@ namespace UTheCat.Jumpvalley.App.Gui
             positionTween = new SceneTreeTween(0.25, Tween.TransitionType.Quad, Tween.EaseType.Out, tree);
             positionTween.InitialValue = -1;
             positionTween.FinalValue = 0;
-            positionTween.OnStep += (object o, float frac) =>
+            positionTween.OnStep += (object o, double _frac) =>
             {
                 float pos = (float)positionTween.GetCurrentValue();
                 menu.Visible = pos < 1f;

--- a/src/app/JumpvalleyPlayer.cs
+++ b/src/app/JumpvalleyPlayer.cs
@@ -231,7 +231,7 @@ namespace UTheCat.Jumpvalley.App
                 InitialValue = 1.0,
                 FinalValue = 0.0
             };
-            introPanelFade.OnStep += (object _o, float frac) =>
+            introPanelFade.OnStep += (object _o, double _frac) =>
             {
                 float opacity = (float)introPanelFade.GetCurrentValue();
 

--- a/src/app/Testing/MethodTweenTest.cs
+++ b/src/app/Testing/MethodTweenTest.cs
@@ -23,7 +23,7 @@ namespace UTheCat.Jumpvalley.App.Testing
             Reset();
             UpdateText();
 
-            tween.OnStep += (object _o, float frac) =>
+            tween.OnStep += (object _o, double _frac) =>
             {
                 //Console.WriteLine($"MethodTween updated fraction: {frac}");
 

--- a/src/core/Gui/BackgroundPanel.cs
+++ b/src/core/Gui/BackgroundPanel.cs
@@ -62,7 +62,7 @@ namespace UTheCat.Jumpvalley.Core.Gui
             {
                 InitialValue = 0
             };
-            opacityTween.OnStep += (object o, float frac) =>
+            opacityTween.OnStep += (object o, double _frac) =>
             {
                 float opacity = (float)opacityTween.GetCurrentValue();
                 panel.Visible = opacity > 0;

--- a/src/core/Music/Playlist.cs
+++ b/src/core/Music/Playlist.cs
@@ -306,7 +306,7 @@ namespace UTheCat.Jumpvalley.Core.Music
                         FinalValue = 1
                     };
 
-                    currentTween.OnStep += (object o, float _frac) =>
+                    currentTween.OnStep += (object o, double _frac) =>
                     {
                         SceneTreeTween t = (SceneTreeTween)o;
                         SetLinearVolumeViaTween(t.GetCurrentValue());

--- a/src/core/Tweening/MethodTween.cs
+++ b/src/core/Tweening/MethodTween.cs
@@ -76,7 +76,7 @@ namespace UTheCat.Jumpvalley.Core.Tweening
         /// <summary>
         /// The speed of the tweening where 1 represents normal speed, 0 represents freezing, and -1 represents backwards at normal speed.
         /// </summary>
-        public float Speed = 1;
+        public double Speed = 1;
 
         /// <summary>
         /// Stopwatch used to keep track of the tweening timestamp
@@ -89,7 +89,7 @@ namespace UTheCat.Jumpvalley.Core.Tweening
         private double lastTimestamp = 0;
 
         private bool _isPlaying = false;
-        private float _currentFraction = 0;
+        private double _currentFraction = 0;
         private double _elapsedTime = 0;
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace UTheCat.Jumpvalley.Core.Tweening
         /// <summary>
         /// The current fraction of the tween that has been completed so far, typically in the range of [0, 1].
         /// </summary>
-        public float CurrentFraction
+        public double CurrentFraction
         {
             get => _currentFraction;
             private set
@@ -150,7 +150,7 @@ namespace UTheCat.Jumpvalley.Core.Tweening
                 else
                 {
                     // get current fraction based on start and end values, along with easing modifiers
-                    CurrentFraction = (float)Tween.InterpolateValue(0f, 1f, value, TransitionTime, TransitionType, EaseType);
+                    CurrentFraction = Tween.InterpolateValue(0.0, 1.0, value, TransitionTime, TransitionType, EaseType).AsDouble();
                 }
             }
         }
@@ -235,14 +235,14 @@ namespace UTheCat.Jumpvalley.Core.Tweening
         /// <summary>
         /// Event that gets raised on each step of the tween until the animation pauses or finishes.
         /// <br/>
-        /// The <see cref="float"/> argument of the event is the current fraction of the tween that has been completed so far, typically in the range of [0, 1].
+        /// The <see cref="double"/> argument of the event is the current fraction of the tween that has been completed so far, typically in the range of [0, 1].
         /// <br/>
         /// <example>
         /// Example usage:
         /// <code>
         /// MethodTween t = new MethodTween();
         /// 
-        /// public void HandleTweenStep(object sender, float frac)
+        /// public void HandleTweenStep(object sender, double frac)
         /// {
         ///     Console.WriteLine($"The current fraction of the tween is {frac}");
         /// }
@@ -254,12 +254,12 @@ namespace UTheCat.Jumpvalley.Core.Tweening
         /// </code>
         /// </example>
         /// </summary>
-        public event EventHandler<float> OnStep;
+        public event EventHandler<double> OnStep;
 
         // Event raising function for OnStep
-        protected void RaiseOnStep(float frac)
+        protected void RaiseOnStep(double frac)
         {
-            EventHandler<float> onStep = OnStep;
+            EventHandler<double> onStep = OnStep;
             if (onStep != null)
             {
                 onStep(this, frac);

--- a/src/core/Tweening/TweenGroup.cs
+++ b/src/core/Tweening/TweenGroup.cs
@@ -17,11 +17,6 @@ namespace UTheCat.Jumpvalley.Core.Tweening
     {
         private Dictionary<TKey, Tween> tweens = new Dictionary<TKey, Tween>();
 
-        public TweenGroup()
-        {
-
-        }
-
         public void Add(TKey key, Tween t)
         {
             if (tweens[key] == null)


### PR DESCRIPTION
This PR changes every numerical value in `MethodTween` to be of type `double`. This is to account for use cases in which tweening is done with *very* large numbers.

This is a breaking change, and as such, multiple classes in Jumpvalley's codebase have been updated to reflect this change.