### PR TITLE
Use X11/XWayland for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Assuming you did this correctly, this tells Linux to allow running the Jumpvalle
 
 #### Wayland and X11
 
-Jumpvalley uses Wayland by default. If you need the app to run on X11 instead, then in the directory where the Jumpvalley executable is located, run this command:
+Jumpvalley uses X11/XWayland by default. If you want the app to run on Wayland instead, then in the directory where the Jumpvalley executable is located, run this command:
 
-`./jumpvalley --display-driver x11`
+`./jumpvalley --display-driver wayland`
 
 ## Documentation
 

--- a/project.godot
+++ b/project.godot
@@ -28,7 +28,6 @@ window/size/viewport_height=1080
 window/size/window_width_override=1152
 window/size/window_height_override=648
 window/stretch/aspect="expand"
-display_server/driver.linuxbsd="wayland"
 window/vsync/vsync_mode=0
 
 [dotnet]


### PR DESCRIPTION
This PR reverts a previous commit that configured Jumpvalley to use Wayland by default.

As a Godot app, Jumpvalley seems to have better compatibility with a wider range of hardware and system configurations when running on X11/XWayland.

Some hardware and system configurations may allow Jumpvalley to perform better on Wayland than on X11/XWayland. The README has been updated in this PR to explain how a user could tell Jumpvalley to run on Wayland.