### PR TITLE
Make fast turn spam-toggle more reliable

### DIFF
--- a/src/app/Players/Movement/FastTurnControl.cs
+++ b/src/app/Players/Movement/FastTurnControl.cs
@@ -14,6 +14,8 @@ namespace UTheCat.Jumpvalley.App.Players.Movement
     {
         private static readonly string INPUT_MAP_FAST_TURN = "character_fast_turn";
 
+        private bool canToggleFastTurn = true;
+
         private BaseMover _mover;
 
         /// <summary>
@@ -110,8 +112,12 @@ namespace UTheCat.Jumpvalley.App.Players.Movement
 
         public override void _UnhandledInput(InputEvent @event)
         {
-            if (Input.IsActionJustPressed(INPUT_MAP_FAST_TURN))
+            if (!Input.IsActionPressed(INPUT_MAP_FAST_TURN)) canToggleFastTurn = true;
+
+            // In case the press state of INPUT_MAP_FAST_TURN switches immediately after the above line of code executes
+            if (canToggleFastTurn && Input.IsActionPressed(INPUT_MAP_FAST_TURN))
             {
+                canToggleFastTurn = false;
                 UserEnabledFastTurn = !UserEnabledFastTurn;
             }
 


### PR DESCRIPTION
This PR adjusts how fast turn control input is handled internally to make the toggling of fast turn more reliable when toggling is requested very rapidly.