### PR TITLE
Allow climbing small steps without jumping

### DIFF
--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=66 format=3 uid="uid://dqjghdruydyeo"]
+[gd_scene load_steps=68 format=3 uid="uid://dqjghdruydyeo"]
 
 [ext_resource type="Material" uid="uid://bq3d6llinnd1i" path="res://textures/moveable_object_indicator.tres" id="1_x3ong"]
 [ext_resource type="Texture2D" uid="uid://d0tpyep45doca" path="res://addons/kenney_prototype_textures/light/texture_07.png" id="2_065hl"]
@@ -189,6 +189,13 @@ size = Vector3(0.25, 0.25, 0.25)
 
 [sub_resource type="ConcavePolygonShape3D" id="ConcavePolygonShape3D_a7o8m"]
 data = PackedVector3Array(-0.125, 0.125, 0.125, 0.125, -0.125, 0.125, -0.125, -0.125, 0.125, -0.125, 0.125, -0.125, -0.125, -0.125, -0.125, 0.125, -0.125, -0.125, -0.125, 0.125, 0.125, -0.125, 0.125, -0.125, 0.125, -0.125, 0.125, -0.125, 0.125, -0.125, 0.125, -0.125, -0.125, 0.125, -0.125, 0.125, -0.125, 0.125, -0.125, -0.125, 0.125, 0.125, -0.125, -0.125, -0.125, -0.125, 0.125, 0.125, -0.125, -0.125, 0.125, -0.125, -0.125, -0.125, -0.125, -0.125, 0.125, 0.125, -0.125, 0.125, -0.125, -0.125, -0.125, 0.125, -0.125, 0.125, 0.125, -0.125, -0.125, -0.125, -0.125, -0.125)
+
+[sub_resource type="PrismMesh" id="PrismMesh_tcnbc"]
+left_to_right = 0.0
+size = Vector3(1, 70, 1)
+
+[sub_resource type="ConcavePolygonShape3D" id="ConcavePolygonShape3D_nfv5x"]
+data = PackedVector3Array(-0.5, 35, 0.5, 0.5, -35, 0.5, -0.5, -35, 0.5, -0.5, 35, -0.5, -0.5, -35, -0.5, 0.5, -35, -0.5, -0.5, 35, 0.5, -0.5, 35, -0.5, 0.5, -35, 0.5, -0.5, 35, -0.5, 0.5, -35, -0.5, 0.5, -35, 0.5, -0.5, 35, -0.5, -0.5, 35, 0.5, -0.5, -35, -0.5, -0.5, 35, 0.5, -0.5, -35, 0.5, -0.5, -35, -0.5, -0.5, -35, 0.5, 0.5, -35, 0.5, -0.5, -35, -0.5, 0.5, -35, 0.5, 0.5, -35, -0.5, -0.5, -35, -0.5)
 
 [node name="Lobby" type="Node3D"]
 
@@ -826,6 +833,16 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 14, 6.5, -44)
 
 [node name="WallhopTest4" parent="StaticObjects/LodgeTest" instance=ExtResource("9_0j8si")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 14, 6.5, -42)
+
+[node name="VeryTallWedge" type="StaticBody3D" parent="StaticObjects"]
+transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 31, 35.5, -19)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="StaticObjects/VeryTallWedge"]
+material_override = ExtResource("4_xv8fq")
+mesh = SubResource("PrismMesh_tcnbc")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticObjects/VeryTallWedge"]
+shape = SubResource("ConcavePolygonShape3D_nfv5x")
 
 [node name="Music" type="Node3D" parent="."]
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -895,7 +895,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                         if (stepClimbResults.TryGetValue("normal", out collisionNormalVariant))
                         {
                             // We only have to give the step-boost if the surface is too steep to just walk on.
-                            if (Math.Acos(collisionNormalVariant.As<Vector3>().Y) > body.FloorMaxAngle)
+                            if (MathF.Acos(collisionNormalVariant.As<Vector3>().Y) > body.FloorMaxAngle)
                             {
                                 // stepClimbResults won't be empty if we can get a position this way
                                 Variant collisionPosVariant;

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -906,7 +906,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                                 if (stepClimbResults.TryGetValue("position", out vStepClimbRayCollisionPos))
                                 {
                                     Vector3 rayCollisionPos = vStepClimbRayCollisionPos.As<Vector3>();
-                                    Vector3 slopeAngleRaycastPositionBase = new Vector3(rayCollisionPos.X, rayCollisionPos.Y - STEP_CLIMB_BOOST_WALL_SLOPE_ANGLE_RAYCAST_Y_OFFSET, rayCollisionPos.Z);
+                                    Vector3 slopeAngleRaycastPositionBase = new Vector3(rayCollisionPos.X, rayCollisionPos.Y + STEP_CLIMB_BOOST_WALL_SLOPE_ANGLE_RAYCAST_Y_OFFSET, rayCollisionPos.Z);
 
                                     // We'll need a separate raycast for detecting the slope angle of the face of the platform that the character is trying to climb up
                                     // (e.g. if this angle is 90 degrees, the face of the platform would be considered a "wall")

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 
 using UTheCat.Jumpvalley.Core.Levels.Interactives.Mechanics;
-using UTheCat.Jumpvalley.Core.Logging;
 using UTheCat.Jumpvalley.Core.Players.Camera;
 
 namespace UTheCat.Jumpvalley.Core.Players.Movement
@@ -75,8 +74,6 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// will cause the climbing shape-cast to not be able to hit the outer surface of the climbable object.
         /// </summary>
         private static readonly float CLIMBING_SHAPE_CAST_Z_OFFSET = 0.005f;
-
-        private ConsoleLogger logger = new ConsoleLogger(nameof(BaseMover), ConsoleLogger.PrintingApi.Godot);
 
         private BodyState _currentBodyState = BodyState.Stopped;
 
@@ -915,8 +912,6 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                                     Variant vSlopeNormal;
                                     if (slopeAngleRaycastResults.TryGetValue("normal", out vSlopeNormal))
                                     {
-                                        logger.Print($"'Wall' slope angle: {Mathf.RadToDeg(MathF.Acos(vSlopeNormal.As<Vector3>().Y))} degrees");
-
                                         // We only have to give the step-boost if the surface is too steep to just walk on.
                                         if (MathF.Acos(vSlopeNormal.As<Vector3>().Y) > body.FloorMaxAngle)
                                         {
@@ -926,12 +921,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                                             if (characterYBoost > 0f && characterYBoost > stepClimbHighestYBoost)
                                             {
                                                 stepClimbHighestYBoost = characterYBoost;
-                                                logger.Print($"Updated step-boost to {stepClimbHighestYBoost} meters");
                                             }
-                                        }
-                                        else
-                                        {
-                                            logger.Print("Not giving step-boost; slope angle is low enough to be walked on.");
                                         }
                                     }
 
@@ -940,10 +930,6 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                                     // // We only want to give the step-climb boost once per frame at most
                                     // if (characterYBoost > stepClimbHighestYBoost) stepClimbHighestYBoost = characterYBoost;
                                 }
-                            }
-                            else
-                            {
-                                logger.Print("Not giving step-boost. This is because the character isn't high enough, the character came into contact with a wallhop, or the surface to step-climb onto is too steep to walk on normally.");
                             }
                         }
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -187,7 +187,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// <br/><br/>
         /// This number is in meters.
         /// </summary>
-        public float AutoClimbStepMaxYBoost = 0.5f;
+        public float AutoClimbStepMaxYBoost = 0.505f;
 
         private bool _isFastTurnEnabled = false;
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -58,11 +58,6 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         }
 
         /// <summary>
-        /// Character height in meters
-        /// </summary>
-        private static readonly float CHARACTER_HEIGHT = 4;
-
-        /// <summary>
         /// The name of the <see cref="CollisionShape3D"/> that should be primarily in charge of handling a character's collision.
         /// </summary>
         public static readonly string CHARACTER_ROOT_COLLIDER_NAME = "RootCollider";

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -852,6 +852,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 {
                     KinematicCollision3D collision = body.GetSlideCollision(i);
                     GodotObject collider = collision.GetCollider();
+                    Vector3 kinematicCollisionPos = collision.GetPosition();
 
                     // See if we can automatically climb a step
                     //
@@ -865,7 +866,6 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                     if (stepClimbMaxYBoost > 0 && collider is PhysicsBody3D)
                     {
                         float characterBottomYPosLocal = -GetCharacterHeight() / 2f;
-                        Vector3 kinematicCollisionPos = collision.GetPosition();
                         Vector3 characterBottom = body.ToGlobal(new Vector3(0, characterBottomYPosLocal, 0));
                         Vector3 characterBottomWithOffset = body.ToGlobal(new Vector3(0, characterBottomYPosLocal + stepClimbMaxYBoost, 0));
                         PhysicsDirectSpaceState3D spaceState = body.GetWorld3D().DirectSpaceState;
@@ -892,10 +892,10 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                             if (collisionNormalToStepOnto != Vector3.Zero && !(MathF.Acos(collisionNormalToStepOnto.Y) > body.FloorMaxAngle))
                             {
                                 // stepClimbResults won't be empty if we can get a position this way
-                                Variant collisionPosVariant;
-                                if (stepClimbResults.TryGetValue("position", out collisionPosVariant))
+                                Variant vStepClimbRayCollisionPos;
+                                if (stepClimbResults.TryGetValue("position", out vStepClimbRayCollisionPos))
                                 {
-                                    Vector3 rayCollisionPos = collisionPosVariant.As<Vector3>();
+                                    Vector3 rayCollisionPos = vStepClimbRayCollisionPos.As<Vector3>();
                                     Vector3 slopeAngleRaycastPositionBase = new Vector3(rayCollisionPos.X, rayCollisionPos.Y - 0.005f, rayCollisionPos.Z);
 
                                     // We'll need a separate raycast for detecting the slope angle of the face of the platform that the character is trying to climb up
@@ -915,7 +915,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                                         // We only have to give the step-boost if the surface is too steep to just walk on.
                                         if (MathF.Acos(vSlopeNormal.As<Vector3>().Y) > body.FloorMaxAngle)
                                         {
-                                            float characterYBoost = rayCollisionPos.Y - characterBottom.Y;// + body.FloorSnapLength;
+                                            float characterYBoost = rayCollisionPos.Y - characterBottom.Y;
 
                                             // We only want to give the step-climb boost once per frame at most
                                             if (characterYBoost > 0f && characterYBoost > stepClimbHighestYBoost)
@@ -924,87 +924,9 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                                             }
                                         }
                                     }
-
-                                    // float characterYBoost = characterBottomWithOffset.Y - rayCollisionPos.Y;
-
-                                    // // We only want to give the step-climb boost once per frame at most
-                                    // if (characterYBoost > stepClimbHighestYBoost) stepClimbHighestYBoost = characterYBoost;
                                 }
                             }
                         }
-
-                        // // stepClimbResults won't be empty if we can get a position this way
-                        // Variant collisionPosVariant;
-                        // if (stepClimbResults.TryGetValue("position", out collisionPosVariant))
-                        // {
-                        //     Vector3 rayCollisionPos = collisionPosVariant.As<Vector3>();
-                        //     Vector3 slopeAngleRaycastPositionBase = new Vector3(rayCollisionPos.X, rayCollisionPos.Y - 0.005f, rayCollisionPos.Z);
-
-                        //     // We'll need a separate raycast for detecting the slope angle of the face of the platform that the character is trying to climb up
-                        //     // (e.g. if this angle is 90 degrees, the face of the platform would be considered a "wall")
-                        //     var slopeAngleRaycastResults = spaceState.IntersectRay(
-                        //         PhysicsRayQueryParameters3D.Create(
-                        //             slopeAngleRaycastPositionBase - finalVelocity * 0.1f,
-                        //             slopeAngleRaycastPositionBase,
-                        //             4294967295,
-                        //             [body.GetRid()]
-                        //         )
-                        //     );
-
-                        //     Variant vSlopeNormal;
-                        //     if (slopeAngleRaycastResults.TryGetValue("normal", out vSlopeNormal))
-                        //     {
-                        //         logger.Print($"'Wall' slope angle: {Mathf.RadToDeg(MathF.Acos(vSlopeNormal.As<Vector3>().Y))} degrees");
-
-                        //         // We only have to give the step-boost if the surface is too steep to just walk on.
-                        //         if (MathF.Acos(vSlopeNormal.As<Vector3>().Y) > body.FloorMaxAngle)
-                        //         {
-                        //             float characterYBoost = characterBottomWithOffset.Y - rayCollisionPos.Y;
-
-                        //             // We only want to give the step-climb boost once per frame at most
-                        //             if (characterYBoost > stepClimbHighestYBoost)
-                        //             {
-                        //                 stepClimbHighestYBoost = characterYBoost;
-                        //                 logger.Print($"Updated step-boost to {stepClimbHighestYBoost} meters");
-                        //             }
-                        //         }
-                        //         else
-                        //         {
-                        //             logger.Print("Not giving step-boost, slope angle is low enough to be walked on.");
-                        //         }
-                        //     }
-
-                        //     // float characterYBoost = characterBottomWithOffset.Y - rayCollisionPos.Y;
-
-                        //     // // We only want to give the step-climb boost once per frame at most
-                        //     // if (characterYBoost > stepClimbHighestYBoost) stepClimbHighestYBoost = characterYBoost;
-                        // }
-
-                        // Raycast hit something if stepClimbResults isn't empty
-                        // Variant collisionNormalVariant;
-                        // if (stepClimbResults.TryGetValue("normal", out collisionNormalVariant))
-                        // {
-                        //     logger.Print($"Slope angle: {Mathf.RadToDeg(MathF.Acos(collisionNormalVariant.As<Vector3>().Y))} degrees");
-
-                        //     // We only have to give the step-boost if the surface is too steep to just walk on.
-                        //     if (MathF.Acos(collisionNormalVariant.As<Vector3>().Y) > body.FloorMaxAngle)
-                        //     {
-                        //         // stepClimbResults won't be empty if we can get a position this way
-                        //         Variant collisionPosVariant;
-                        //         if (stepClimbResults.TryGetValue("position", out collisionPosVariant))
-                        //         {
-                        //             Vector3 rayCollisionPos = collisionPosVariant.As<Vector3>();
-                        //             float characterYBoost = characterBottomWithOffset.Y - rayCollisionPos.Y;
-
-                        //             // We only want to give the step-climb boost once per frame at most
-                        //             if (characterYBoost > stepClimbHighestYBoost) stepClimbHighestYBoost = characterYBoost;
-                        //         }
-                        //     }
-                        //     else
-                        //     {
-                        //         logger.Print("Not giving step-boost, slope angle is low enough to be walked on.");
-                        //     }
-                        // }
                     }
 
                     if (collider is RigidBody3D rigidBody)
@@ -1012,7 +934,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                         RigidBodyPusher pusher;
 
                         Vector3 collisionNormal = collision.GetNormal();
-                        Vector3 forcePositionOffset = collision.GetPosition() - rigidBody.GlobalPosition;
+                        Vector3 forcePositionOffset = kinematicCollisionPos - rigidBody.GlobalPosition;
 
                         // CALCULATIONS FOR RIGIDBODY3D ATTEMPTS TO PUSH CHARACTER //
 
@@ -1085,12 +1007,11 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 }
 
                 // Apply step climb if there is one for this frame
+                //
+                // The result of the step climb should be that the character is standing on a surface
+                // whose slope angle is low enough to be considered a "floor"
                 if (stepClimbHighestYBoost > 0f)
                 {
-                    // The result of the step climb is that the character is standing on a surface
-                    // whose slope angle is low enough to be considered a "floor"
-                    //finalVelocity.Y = MathF.Max(0, finalVelocity.Y);
-
                     float jumpVelocity = JumpVelocity;
 
                     // Give them a small y-velocity boost if needed so they can climb the step without jumping
@@ -1099,10 +1020,6 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                     // The above logic causes the character to sometimes get stuck on ledges when trying to step-climb.
                     // When this happens, allow the player to jump to escape this.
                     if (IsJumping) finalVelocity.Y = Math.Max(jumpVelocity, finalVelocity.Y);
-
-                    // Vector3 pos = body.GlobalPosition;
-                    // pos.Y += stepClimbHighestYBoost;
-                    // body.GlobalPosition = pos;
                 }
 
                 // Store the current velocity for the next physics frame to use.

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -180,11 +180,14 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// <summary>
         /// When making contact with a step and travelling towards the step's position, the character
         /// will automatically climb the step without jumping if the character Y-position boost needed
-        /// to achieve this is within the range of (0, <i>the value of this field</i>].
+        /// to achieve this is within the range of (0, <i>the value of this field</i>]. This also applies
+        /// if the contact was made midair.
+        /// <br/><br/>
+        /// To avoid potentially unwanted upward boosts, avoid setting this value too high.
         /// <br/><br/>
         /// This number is in meters.
         /// </summary>
-        public float AutoClimbStepMaxYBoost = 6f;
+        public float AutoClimbStepMaxYBoost = 0.3f;
 
         private bool _isFastTurnEnabled = false;
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -1105,7 +1105,14 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                     // whose slope angle is low enough to be considered a "floor"
                     //finalVelocity.Y = MathF.Max(0, finalVelocity.Y);
 
-                    finalVelocity.Y = Math.Max(Math.Min(stepClimbHighestYBoost * Gravity / 2f, JumpVelocity / 2f), finalVelocity.Y);
+                    float jumpVelocity = JumpVelocity;
+
+                    // Give them a small y-velocity boost if needed so they can climb the step without jumping
+                    finalVelocity.Y = Math.Max(Math.Min(stepClimbHighestYBoost * Gravity / 2f, jumpVelocity / 2f), finalVelocity.Y);
+
+                    // The above logic causes the character to sometimes get stuck on ledges when trying to step-climb.
+                    // When this happens, allow the player to jump to escape this.
+                    if (IsJumping) finalVelocity.Y = Math.Max(jumpVelocity, finalVelocity.Y);
 
                     // Vector3 pos = body.GlobalPosition;
                     // pos.Y += stepClimbHighestYBoost;

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -75,6 +75,16 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// </summary>
         private static readonly float CLIMBING_SHAPE_CAST_Z_OFFSET = 0.005f;
 
+        /// <summary>
+        /// This number is in meters.
+        /// </summary>
+        private static readonly float STEP_CLIMB_BOOST_WALL_SLOPE_ANGLE_RAYCAST_Y_OFFSET = -0.005f;
+
+        /// <summary>
+        /// This number is in meters.
+        /// </summary>
+        private static readonly float STEP_CLIMB_BOOST_WALL_SLOPE_ANGLE_RAYCAST_LENGTH = 0.1f;
+
         private BodyState _currentBodyState = BodyState.Stopped;
 
         /// <summary>
@@ -896,13 +906,13 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                                 if (stepClimbResults.TryGetValue("position", out vStepClimbRayCollisionPos))
                                 {
                                     Vector3 rayCollisionPos = vStepClimbRayCollisionPos.As<Vector3>();
-                                    Vector3 slopeAngleRaycastPositionBase = new Vector3(rayCollisionPos.X, rayCollisionPos.Y - 0.005f, rayCollisionPos.Z);
+                                    Vector3 slopeAngleRaycastPositionBase = new Vector3(rayCollisionPos.X, rayCollisionPos.Y - STEP_CLIMB_BOOST_WALL_SLOPE_ANGLE_RAYCAST_Y_OFFSET, rayCollisionPos.Z);
 
                                     // We'll need a separate raycast for detecting the slope angle of the face of the platform that the character is trying to climb up
                                     // (e.g. if this angle is 90 degrees, the face of the platform would be considered a "wall")
                                     var slopeAngleRaycastResults = spaceState.IntersectRay(
                                         PhysicsRayQueryParameters3D.Create(
-                                            slopeAngleRaycastPositionBase - finalVelocity * 0.1f,
+                                            slopeAngleRaycastPositionBase - new Vector3(finalVelocity.X, 0, finalVelocity.Z).Normalized() * STEP_CLIMB_BOOST_WALL_SLOPE_ANGLE_RAYCAST_LENGTH,
                                             slopeAngleRaycastPositionBase,
                                             4294967295,
                                             [body.GetRid()]

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -187,7 +187,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// <br/><br/>
         /// This number is in meters.
         /// </summary>
-        public float AutoClimbStepMaxYBoost = 0.3f;
+        public float AutoClimbStepMaxYBoost = 0.5f;
 
         private bool _isFastTurnEnabled = false;
 
@@ -1103,11 +1103,13 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 {
                     // The result of the step climb is that the character is standing on a surface
                     // whose slope angle is low enough to be considered a "floor"
-                    finalVelocity.Y = MathF.Max(0, finalVelocity.Y);
+                    //finalVelocity.Y = MathF.Max(0, finalVelocity.Y);
 
-                    Vector3 pos = body.GlobalPosition;
-                    pos.Y += stepClimbHighestYBoost;
-                    body.GlobalPosition = pos;
+                    finalVelocity.Y = Math.Max(Math.Min(stepClimbHighestYBoost * Gravity / 2f, JumpVelocity / 2f), finalVelocity.Y);
+
+                    // Vector3 pos = body.GlobalPosition;
+                    // pos.Y += stepClimbHighestYBoost;
+                    // body.GlobalPosition = pos;
                 }
 
                 // Store the current velocity for the next physics frame to use.


### PR DESCRIPTION
As of this PR, the player's character will automatically climb steps whose height is `x` meters or less, without jumping. `x` is 0.505 by default.

This PR also helps increase lenience for long jumps by giving the player a small boost up in cases where the player's character would've otherwise been *slightly* too low to make the jump.


https://github.com/user-attachments/assets/04ae74fa-1e3e-4cb8-b266-0626ea6f862f

