### PR TITLE
Expand character safe collision margin

### DIFF
--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -10,7 +10,7 @@ transparency = 1
 albedo_color = Color(0.631373, 0.631373, 0.631373, 0.25098)
 
 [sub_resource type="BoxMesh" id="BoxMesh_rl4hs"]
-size = Vector3(1.005, 2.005, 0.505)
+size = Vector3(1.05, 2.1, 0.55)
 
 [node name="Character" type="CharacterBody3D"]
 collision_layer = 5
@@ -18,7 +18,7 @@ collision_mask = 5
 floor_constant_speed = true
 floor_max_angle = 1.309
 platform_floor_layers = 4294967291
-safe_margin = 0.01
+safe_margin = 0.05
 metadata/custom_overall_bounding_box = AABB(-0.5, -1, -0.25, 1, 2, 0.5)
 
 [node name="_InteractiveBoundingBox" type="Node" parent="."]

--- a/scenes/player/character_body.tscn
+++ b/scenes/player/character_body.tscn
@@ -4,7 +4,7 @@
 
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_7bhqx"]
 radius = 0.25
-height = 1.0
+height = 1.1
 
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_mx087"]
 radius = 0.15


### PR DESCRIPTION
The safe-collision margin of the player's character has been increased from 0.01 to 0.05 as of this PR.