### PR TITLE
Improve camera-turning user interface (2025-08-19)

### DIFF
--- a/src/app/Players/Camera/UserInputCamera.cs
+++ b/src/app/Players/Camera/UserInputCamera.cs
@@ -41,15 +41,21 @@ namespace UTheCat.Jumpvalley.App.Players.Camera
         public override void _UnhandledInput(InputEvent @event)
         {
             // Handle camera turning input
-            if (Input.IsActionJustPressed(INPUT_CAMERA_PAN))
+            if (Input.IsActionPressed(INPUT_CAMERA_PAN))
             {
-                IsTurningCamera = true;
-                Input.MouseMode = Input.MouseModeEnum.Captured;
+                if (!IsTurningCamera)
+                {
+                    IsTurningCamera = true;
+                    Input.MouseMode = Input.MouseModeEnum.Captured;
+                }
             }
-            else if (Input.IsActionJustReleased(INPUT_CAMERA_PAN))
+            else
             {
-                IsTurningCamera = false;
-                Input.MouseMode = Input.MouseModeEnum.Visible;
+                if (IsTurningCamera)
+                {
+                    IsTurningCamera = false;
+                    Input.MouseMode = Input.MouseModeEnum.Visible;
+                }
             }
 
             // Turn camera based on mouse input

--- a/src/app/Players/Camera/UserInputCamera.cs
+++ b/src/app/Players/Camera/UserInputCamera.cs
@@ -41,8 +41,6 @@ namespace UTheCat.Jumpvalley.App.Players.Camera
 
         public override void _UnhandledInput(InputEvent @event)
         {
-            InputEventMouseMotion mouseEvent = @event as InputEventMouseMotion;
-
             // Handle camera turning input
             if (Input.IsActionPressed(INPUT_CAMERA_PAN))
             {
@@ -70,7 +68,7 @@ namespace UTheCat.Jumpvalley.App.Players.Camera
             }
 
             // Turn camera based on mouse input
-            if (IsTurningCamera && mouseEvent != null)
+            if (IsTurningCamera && @event is InputEventMouseMotion mouseEvent)
             {
                 Vector2 mouseEventRelative = mouseEvent.Relative;
 

--- a/src/app/Players/Camera/UserInputCamera.cs
+++ b/src/app/Players/Camera/UserInputCamera.cs
@@ -35,17 +35,27 @@ namespace UTheCat.Jumpvalley.App.Players.Camera
         public float CameraZoomAdjustment = 1;
 
         private float cameraPanningSpeedMultiplier = 0.02f;
+        private Vector2I originalCursorPos = Vector2I.Zero;
 
         public UserInputCamera() : base() { }
 
         public override void _UnhandledInput(InputEvent @event)
         {
+            InputEventMouseMotion mouseEvent = @event as InputEventMouseMotion;
+
             // Handle camera turning input
             if (Input.IsActionPressed(INPUT_CAMERA_PAN))
             {
                 if (!IsTurningCamera)
                 {
                     IsTurningCamera = true;
+
+                    // MouseGetPosition() gets cursor position in screen coordinates.
+                    // However, we want to store the mouse position relative to the position of the client area (the app window).
+                    // This also needs to come before we set mouse mode to "Captured" so we can retrieve the mouse position
+                    // before moving the cursor to the center of the window for camera turning.
+                    originalCursorPos = DisplayServer.MouseGetPosition() - DisplayServer.WindowGetPosition();
+
                     Input.MouseMode = Input.MouseModeEnum.Captured;
                 }
             }
@@ -55,11 +65,12 @@ namespace UTheCat.Jumpvalley.App.Players.Camera
                 {
                     IsTurningCamera = false;
                     Input.MouseMode = Input.MouseModeEnum.Visible;
+                    DisplayServer.WarpMouse(originalCursorPos);
                 }
             }
 
             // Turn camera based on mouse input
-            if (IsTurningCamera && @event is InputEventMouseMotion mouseEvent)
+            if (IsTurningCamera && mouseEvent != null)
             {
                 Vector2 mouseEventRelative = mouseEvent.Relative;
 


### PR DESCRIPTION
As of this PR:

- Camera turning should be more responsive (app responds slightly sooner when camera wants to start and stop turning the camera)
- When user stops turning camera, the mouse cursor returns to the position it was at just before the user started turning the camera