### PR TITLE
Fix camera being turned too quickly

### DIFF
--- a/src/app/Players/Camera/UserInputCamera.cs
+++ b/src/app/Players/Camera/UserInputCamera.cs
@@ -63,7 +63,6 @@ namespace UTheCat.Jumpvalley.App.Players.Camera
                 if (cameraTurnOverlay != null && cameraTurnOverlay.Visible)
                 {
                     MouseTurnCamera(mouseEvent);
-                    GD.Print("Turning camera from _Input.");
                 }
             }
 
@@ -106,14 +105,12 @@ namespace UTheCat.Jumpvalley.App.Players.Camera
                 {
                     canTurnCameraInUnderscoreInput = false;
                     MouseTurnCamera(mouseEvent);
-                    GD.Print("Turning camera from _UnhandledInput.");
                 }
                 {
                     if (!canTurnCameraInUnderscoreInput)
                     {
                         canTurnCameraInUnderscoreInput = true;
                         MouseTurnCamera(mouseEvent);
-                        GD.Print("Turning camera from _UnhandledInput.");
                     }
                 }
             }
@@ -137,7 +134,6 @@ namespace UTheCat.Jumpvalley.App.Players.Camera
         {
             if (IsTurningCamera)
             {
-                GD.Print("stop turning camera");
                 IsTurningCamera = false;
                 canTurnCameraInUnderscoreInput = false;
                 Input.MouseMode = Input.MouseModeEnum.Visible;

--- a/src/app/Players/Camera/UserInputCamera.cs
+++ b/src/app/Players/Camera/UserInputCamera.cs
@@ -60,7 +60,11 @@ namespace UTheCat.Jumpvalley.App.Players.Camera
             if (IsTurningCamera && canTurnCameraInUnderscoreInput && @event is InputEventMouseMotion mouseEvent)
             {
                 Control cameraTurnOverlay = CameraTurnInvisibleOverlay;
-                if (cameraTurnOverlay != null && cameraTurnOverlay.Visible) MouseTurnCamera(mouseEvent);
+                if (cameraTurnOverlay != null && cameraTurnOverlay.Visible)
+                {
+                    MouseTurnCamera(mouseEvent);
+                    GD.Print("Turning camera from _Input.");
+                }
             }
 
             base._Input(@event);
@@ -68,6 +72,8 @@ namespace UTheCat.Jumpvalley.App.Players.Camera
 
         public override void _UnhandledInput(InputEvent @event)
         {
+            Control cameraTurnOverlay = CameraTurnInvisibleOverlay;
+
             // Handle camera turning input
             if (Input.IsActionPressed(INPUT_CAMERA_PAN))
             {
@@ -81,7 +87,6 @@ namespace UTheCat.Jumpvalley.App.Players.Camera
                     // before moving the cursor to the center of the window for camera turning.
                     originalCursorPos = DisplayServer.MouseGetPosition() - DisplayServer.WindowGetPosition();
 
-                    Control cameraTurnOverlay = CameraTurnInvisibleOverlay;
                     if (cameraTurnOverlay != null) cameraTurnOverlay.Visible = true;
 
                     Input.MouseMode = Input.MouseModeEnum.Captured;
@@ -97,9 +102,20 @@ namespace UTheCat.Jumpvalley.App.Players.Camera
             {
                 // Should come before we set canTurnCameraInUnderscoreInput to true
                 // as a means of preventing a race condition
-                MouseTurnCamera(mouseEvent);
-
-                canTurnCameraInUnderscoreInput = true;
+                if (cameraTurnOverlay == null)
+                {
+                    canTurnCameraInUnderscoreInput = false;
+                    MouseTurnCamera(mouseEvent);
+                    GD.Print("Turning camera from _UnhandledInput.");
+                }
+                {
+                    if (!canTurnCameraInUnderscoreInput)
+                    {
+                        canTurnCameraInUnderscoreInput = true;
+                        MouseTurnCamera(mouseEvent);
+                        GD.Print("Turning camera from _UnhandledInput.");
+                    }
+                }
             }
 
             base._Input(@event);
@@ -121,6 +137,7 @@ namespace UTheCat.Jumpvalley.App.Players.Camera
         {
             if (IsTurningCamera)
             {
+                GD.Print("stop turning camera");
                 IsTurningCamera = false;
                 canTurnCameraInUnderscoreInput = false;
                 Input.MouseMode = Input.MouseModeEnum.Visible;


### PR DESCRIPTION
This PR fixes a bug caused by changes made in PR #124. The bug caused the camera to turn too quickly based on user input due to the camera turn being made in both the `UserInputCamera._Input()` and `UserInputCamera._UnhandledInput()` methods at the same time for the same user input.

This bug fix corrects this behavior by ensuring that a single camera turn input can only turn the camera in either `UserInputCamera._Input()` *or* `UserInputCamera._UnhandledInput()`, but not both at the same time.