### PR TITLE
Don't step-climb objects that are already being climbed

### DIFF
--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -873,7 +873,11 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                     // In other cases, the player wants to climb up a short platform (e.g. staircase step) without jumping.
                     // We want to allow this.
                     float stepClimbMaxYBoost = AutoClimbStepMaxYBoost;
-                    if (stepClimbMaxYBoost > 0 && collider is PhysicsBody3D)
+                    if (
+                        stepClimbMaxYBoost > 0
+                        && collider is PhysicsBody3D physicsBodyCollider
+                        && (!IsClimbing || CurrentClimber == null || physicsBodyCollider != CurrentClimber.CurrentlyClimbedObject)
+                        )
                     {
                         float characterBottomYPosLocal = -GetCharacterHeight() / 2f;
                         Vector3 characterBottom = body.ToGlobal(new Vector3(0, characterBottomYPosLocal, 0));


### PR DESCRIPTION
This is to avoid unwanted step-climb boosting when the character is already climbing a climbable object/ladder. Step-climb boosting can still be done for climbable objects/ladders when they're not being climbed by the character (e.g. as a ladder).

The step-climb boost and normal climbing are different. See PR #122 for details on the step-climb boost.