### PR TITLE
Revert collision margin expansion

### DIFF
--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -10,7 +10,7 @@ transparency = 1
 albedo_color = Color(0.631373, 0.631373, 0.631373, 0.25098)
 
 [sub_resource type="BoxMesh" id="BoxMesh_rl4hs"]
-size = Vector3(1.05, 2.1, 0.55)
+size = Vector3(1, 2, 0.5)
 
 [node name="Character" type="CharacterBody3D"]
 collision_layer = 5
@@ -34,4 +34,4 @@ skeleton = NodePath("../..")
 [node name="CharacterBody" parent="." instance=ExtResource("2_3ohbj")]
 
 [node name="CameraFocus" type="Node3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.775, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.75, 0)

--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -18,7 +18,6 @@ collision_mask = 5
 floor_constant_speed = true
 floor_max_angle = 1.309
 platform_floor_layers = 4294967291
-safe_margin = 0.05
 metadata/custom_overall_bounding_box = AABB(-0.5, -1, -0.25, 1, 2, 0.5)
 
 [node name="_InteractiveBoundingBox" type="Node" parent="."]

--- a/scenes/player/character_body.tscn
+++ b/scenes/player/character_body.tscn
@@ -4,14 +4,14 @@
 
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_7bhqx"]
 radius = 0.25
-height = 1.1
+height = 1.0
 
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_mx087"]
 radius = 0.15
 height = 0.75
 
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_d4gh2"]
-height = 1.55
+height = 1.5
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_u5oda"]
 albedo_color = Color(0.152941, 0.152941, 0.152941, 1)
@@ -51,7 +51,7 @@ mesh = SubResource("CapsuleMesh_mx087")
 skeleton = NodePath("")
 
 [node name="Torso" type="Node3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.275, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
 
 [node name="Mesh" type="MeshInstance3D" parent="Torso"]
 material_override = ExtResource("1_jhmwb")
@@ -66,7 +66,7 @@ visible = false
 skeleton = NodePath("../../..")
 
 [node name="Face" type="Node3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.064, 0.617, -0.443)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.064, 0.6, -0.443)
 
 [node name="Mesh" type="MeshInstance3D" parent="Face"]
 transform = Transform3D(-1.31134e-07, 3, 0, -3, -1.31134e-07, 0, 0, 0, 3, 0, 0, 0)


### PR DESCRIPTION
This PR reverts the expansions of the character safe-collision margin. Specifically, the safe-collision margin has been reduced from 0.05 meters back to 0.001 meters.