### PR TITLE
Improve object pushing

### DIFF
--- a/scenes/lobby/fast_rolling_ball.tscn
+++ b/scenes/lobby/fast_rolling_ball.tscn
@@ -36,7 +36,7 @@ mesh = SubResource("BoxMesh_rbx7a")
 
 [node name="Ball" type="RigidBody3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 45, 2.5, 0)
-mass = 526.0
+mass = 92.0
 script = ExtResource("2_41y5u")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Ball"]

--- a/scenes/lobby/fast_rolling_ball.tscn
+++ b/scenes/lobby/fast_rolling_ball.tscn
@@ -36,7 +36,7 @@ mesh = SubResource("BoxMesh_rbx7a")
 
 [node name="Ball" type="RigidBody3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 45, 2.5, 0)
-mass = 92.0
+mass = 206.0
 script = ExtResource("2_41y5u")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Ball"]

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -701,8 +701,14 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             /// </summary>
             private static readonly float GET_CHAR_VELOCITY_CHANGE_RAY_END_OFFSET = 0.5f;
 
+            /// <summary>
+            /// The colliding rigid body.
+            /// </summary>
             public RigidBody3D RigidBody = null;
 
+            /// <summary>
+            /// The colliding character.
+            /// </summary>
             public CharacterBody3D Character = null;
 
             /// <summary>

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -795,8 +795,8 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 Variant vRaycastCollider;
                 if (raycastResult.TryGetValue("collider", out vRaycastCollider))
                 {
-                    CharacterBody3D cBody = vRaycastCollider.As<CharacterBody3D>();
-                    if (cBody != null && Character == cBody)
+                    GodotObject oCollider = vRaycastCollider.AsGodotObject();
+                    if (oCollider != null && oCollider is CharacterBody3D cBody && cBody == Character)
                     {
                         Variant vCollisionNormal;
                         if (raycastResult.TryGetValue("normal", out vCollisionNormal)) negativeCharacterCollisionNormal = -vCollisionNormal.As<Vector3>();
@@ -804,15 +804,15 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 }
 
                 // The amount in which finalVelocity (character velocity) has to change to match rigidBody.Velocity.
-                float charVelocityRigidBodyVelocityDiff = RigidBody.LinearVelocity.Dot(negativeCharacterCollisionNormal) - characterCurrentVelocity.Dot(negativeCharacterCollisionNormal);
+                float rigidBodyVelocityCharVelocityDiff = RigidBody.LinearVelocity.Dot(negativeCharacterCollisionNormal) - characterCurrentVelocity.Dot(negativeCharacterCollisionNormal);
 
                 // If we know for sure that applying the force would be physically impossible, don't apply the force.
-                if (charVelocityRigidBodyVelocityDiff <= 0) return Vector3.Zero;
+                if (rigidBodyVelocityCharVelocityDiff <= 0) return Vector3.Zero;
 
                 // Objects heavier than the character should be able to push the character with greater force.
                 float massRatio = RigidBody.Mass / Mover.Mass;
 
-                Vector3 characterPushForce = CharacterPushCollisionNormal * charVelocityRigidBodyVelocityDiff * massRatio * Mover.CharacterPushForceMultiplier;
+                Vector3 characterPushForce = CharacterPushCollisionNormal * rigidBodyVelocityCharVelocityDiff * massRatio * Mover.CharacterPushForceMultiplier;
 
                 // Some rigid bodies absorb force on impact. Account for this.
                 PhysicsMaterial rigidBodyPhysicsMaterial = RigidBody.PhysicsMaterialOverride;

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -703,12 +703,13 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             /// List of global-space coordinates that Body and Character are touching during the current physics frame
             /// </summary>
             public List<Vector3> CollisionPoints = [];
-
+            
             /// <summary>
-            /// The point of collision between the character and the rigid body that's closest to the character's position. This vector is the
-            /// position offset of the point of collision from the center of the character, and is not in global-space coordinates.
+            /// The closest distance between the center of the character and
+            /// the point at which <see cref="Body"/> and <see cref="Character"/> collided.
             /// </summary>
-            public Vector3 ClosestPositionOffsetFromCharacterCenter = Vector3.Zero;
+            public float CharCenterToCollisionPosSmallestDist = 0f;
+
             /// <summary>
             /// Where force should be applied to <see cref="Body"/> and <see cref="Character"/> in global coordinates.  
             /// </summary>
@@ -1037,7 +1038,8 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                             pusher.CollisionPoints.Add(kinematicCollisionPos);
 
                             //Vector3 centerOfMass = rigidBody.CenterOfMass;
-                            if (collisionPosCharacterPosDiff.Length() < pusher.ClosestPositionOffsetFromCharacterCenter.Length())
+                            float collisionPosToCharacterPosDistance = collisionPosCharacterPosDiff.Length();
+                            if (collisionPosToCharacterPosDistance < pusher.CharCenterToCollisionPosSmallestDist)
                             {
                                 // Character to be pushed by RigidBody3D shouldn't change while we're scanning
                                 // for more collision points between the character and the RigidBody3D, and so,
@@ -1046,7 +1048,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                                 // However, using a different collision point could potentially mean that the character was hit by the RigidBody3D
                                 // at a different collision normal, and so, we still want to update character push force when we've found a collision point
                                 // closer to the center of the character.
-                                pusher.ClosestPositionOffsetFromCharacterCenter = collisionPosCharacterPosDiff;
+                                pusher.CharCenterToCollisionPosSmallestDist = collisionPosToCharacterPosDistance;
                                 pusher.CharacterPushForce = characterPushForce;
                             }
                         }
@@ -1055,7 +1057,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                             pusher = new RigidBodyPusher
                             {
                                 Body = rigidBody,
-                                ClosestPositionOffsetFromCharacterCenter = collisionPosCharacterPosDiff,
+                                CharCenterToCollisionPosSmallestDist = collisionPosCharacterPosDiff.Length(),
                                 Character = Body,
                                 CharacterPushForce = characterPushForce,
                                 Mover = this

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -768,14 +768,15 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             public Vector3 GetCharacterVelocityChange(Vector3 characterCurrentVelocity)
             {
                 // The amount in which finalVelocity (character velocity) has to change to match rigidBody.Velocity.
-                // This number also has a minimum of 0 to ensure that the rigid body only pushes the character when the rigid body
-                // is travelling towards the character.
-                float characterVelocityDiff = Math.Max(0f, Body.LinearVelocity.Dot(CollisionNormal) - characterCurrentVelocity.Dot(-CollisionNormal));
+                float charVelocityRigidBodyVelocityDiff = Body.LinearVelocity.Dot(CollisionNormal) - characterCurrentVelocity.Dot(-CollisionNormal);
+
+                // If applying the force would be physically impossible, don't apply the force.
+                if (charVelocityRigidBodyVelocityDiff <= 0) return Vector3.Zero;
 
                 // Objects heavier than the character should be able to push the character with greater force.
                 float massRatio = Body.Mass / Mover.Mass;
 
-                Vector3 characterPushForce = CollisionNormal * characterVelocityDiff * massRatio * Mover.CharacterPushForceMultiplier;
+                Vector3 characterPushForce = CollisionNormal * charVelocityRigidBodyVelocityDiff * massRatio * Mover.CharacterPushForceMultiplier;
 
                 // Some rigid bodies absorb force on impact. Account for this.
                 PhysicsMaterial rigidBodyPhysicsMaterial = Body.PhysicsMaterialOverride;

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -780,6 +780,10 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             /// <param name="characterCurrentVelocity">The current (or next) velocity of the character</param>
             public Vector3 GetCharacterVelocityChange(Vector3 characterCurrentVelocity)
             {
+                Vector3 rigidBodyVelocity = RigidBody.LinearVelocity;
+
+                if (rigidBodyVelocity == Vector3.Zero) return Vector3.Zero;
+
                 // Use a raycast to determine the collision normal of the character that was touched by the rigid body, using
                 // CharacterPushCollisionNormal as a fallback.
                 Vector3 avgCollisionPoint = GetAvgCollisionPoint();
@@ -804,7 +808,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 }
 
                 // The amount in which finalVelocity (character velocity) has to change to match rigidBody.Velocity.
-                float rigidBodyVelocityCharVelocityDiff = RigidBody.LinearVelocity.Dot(negativeCharacterCollisionNormal) - characterCurrentVelocity.Dot(negativeCharacterCollisionNormal);
+                float rigidBodyVelocityCharVelocityDiff = rigidBodyVelocity.Dot(negativeCharacterCollisionNormal) - characterCurrentVelocity.Dot(negativeCharacterCollisionNormal);
 
                 // If we know for sure that applying the force would be physically impossible, don't apply the force.
                 if (rigidBodyVelocityCharVelocityDiff <= 0) return Vector3.Zero;
@@ -812,7 +816,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 // Objects heavier than the character should be able to push the character with greater force.
                 float massRatio = RigidBody.Mass / Mover.Mass;
 
-                Vector3 characterPushForce = CharacterPushCollisionNormal * rigidBodyVelocityCharVelocityDiff * massRatio * Mover.CharacterPushForceMultiplier;
+                Vector3 characterPushForce = rigidBodyVelocity.Normalized() * rigidBodyVelocityCharVelocityDiff * massRatio * Mover.CharacterPushForceMultiplier;
 
                 // Some rigid bodies absorb force on impact. Account for this.
                 PhysicsMaterial rigidBodyPhysicsMaterial = RigidBody.PhysicsMaterialOverride;

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -884,11 +884,9 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
 
                 float stepClimbHighestYBoost = 0f;
 
-                // Figure out how to push objects we've come into contact with. This part intentionally comes before the call to MoveAndSlide().
-                // Thanks to this forum post for helping me figure out how to implement this:
-                // https://forum.godotengine.org/t/how-to-fix-movable-box-physics/75853
-                // as well as this code snippet by majikayogames on GitHub
-                // https://gist.github.com/majikayogames/cf013c3091e9a313e322889332eca109
+                // Handle collisions.
+                // For performance reasons, we handle the step-climb boost, as well as rigid-body and character pushing,
+                // in the same iteration within this loop.
                 Dictionary<RigidBody3D, RigidBodyPusher> currentFrameRigidBodyPushers = [];
                 for (int i = 0; i < body.GetSlideCollisionCount(); i++)
                 {
@@ -896,7 +894,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                     GodotObject collider = collision.GetCollider();
                     Vector3 kinematicCollisionPos = collision.GetPosition();
 
-                    // See if we can automatically climb a step
+                    // See if we can automatically climb a step (perform a "step-climb boost")
                     //
                     // In some cases, the player will just barely miss a platform because they almost (but didn't)
                     // gain enough height (e.g. after a high or long jump).

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -691,7 +691,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// </summary>
         class RigidBodyPusher
         {
-            public RigidBody3D Body = null;
+            public RigidBody3D RigidBody = null;
 
             public CharacterBody3D Character = null;
 
@@ -707,18 +707,18 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
 
             /// <summary>
             /// The closest distance between the center of the character and
-            /// the point at which <see cref="Body"/> and <see cref="Character"/> collided.
+            /// the point at which <see cref="RigidBody"/> and <see cref="Character"/> collided.
             /// </summary>
             public float CharCenterToCollisionPosSmallestDist = 0f;
 
             /// <summary>
-            /// Force applied by <see cref="Body"/> on <see cref="Character"/>  
+            /// Force applied by <see cref="RigidBody"/> on <see cref="Character"/>  
             /// </summary>
             //public Vector3 CharacterPushForce = Vector3.Zero;
 
             /// <summary>
             /// Collision normal to use when figuring out how to apply force to the character.
-            /// This collision normal is the normal on the rigid body in which <see cref="Body"/>
+            /// This collision normal is the normal on the rigid body in which <see cref="RigidBody"/>
             /// and <see cref="Character"/> touched.  
             /// </summary>
             public Vector3 CollisionNormal = Vector3.Zero;
@@ -738,7 +738,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             }
 
             /// <summary>
-            /// Pushes <see cref="Body"/>. 
+            /// Pushes <see cref="RigidBody"/>. 
             /// </summary>
             /// <param name="characterCurrentVelocity"></param>
             /// <param name="characterTargetVelocity"></param>
@@ -749,15 +749,15 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 Vector3 charVelocity = (characterCurrentVelocity.Length() > characterTargetVelocity.Length()) ? characterCurrentVelocity : characterTargetVelocity;
 
                 Vector3 pushDirection = charVelocity.Normalized();
-                float forceMultiplier = charVelocity.Dot(pushDirection) - Body.LinearVelocity.Dot(pushDirection);
+                float forceMultiplier = charVelocity.Dot(pushDirection) - RigidBody.LinearVelocity.Dot(pushDirection);
 
                 // If character doesn't have enough velocity to overcome rigid body velocity
                 // or if we know for sure that force application is physically impossible, stop.
                 if (forceMultiplier <= 0) return;
 
-                forceMultiplier *= Mover.ForceMultiplier * Mover.Mass / Body.Mass;
+                forceMultiplier *= Mover.ForceMultiplier * Mover.Mass / RigidBody.Mass;
 
-                Body.ApplyForce(pushDirection * forceMultiplier, GetAvgCollisionPoint() - Body.GlobalPosition);
+                RigidBody.ApplyForce(pushDirection * forceMultiplier, GetAvgCollisionPoint() - RigidBody.GlobalPosition);
             }
 
             /// <summary>
@@ -768,18 +768,18 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             public Vector3 GetCharacterVelocityChange(Vector3 characterCurrentVelocity)
             {
                 // The amount in which finalVelocity (character velocity) has to change to match rigidBody.Velocity.
-                float charVelocityRigidBodyVelocityDiff = Body.LinearVelocity.Dot(CollisionNormal) - characterCurrentVelocity.Dot(-CollisionNormal);
+                float charVelocityRigidBodyVelocityDiff = RigidBody.LinearVelocity.Dot(CollisionNormal) - characterCurrentVelocity.Dot(-CollisionNormal);
 
                 // If we know for sure that applying the force would be physically impossible, don't apply the force.
                 if (charVelocityRigidBodyVelocityDiff <= 0) return Vector3.Zero;
 
                 // Objects heavier than the character should be able to push the character with greater force.
-                float massRatio = Body.Mass / Mover.Mass;
+                float massRatio = RigidBody.Mass / Mover.Mass;
 
                 Vector3 characterPushForce = CollisionNormal * charVelocityRigidBodyVelocityDiff * massRatio * Mover.CharacterPushForceMultiplier;
 
                 // Some rigid bodies absorb force on impact. Account for this.
-                PhysicsMaterial rigidBodyPhysicsMaterial = Body.PhysicsMaterialOverride;
+                PhysicsMaterial rigidBodyPhysicsMaterial = RigidBody.PhysicsMaterialOverride;
                 if (rigidBodyPhysicsMaterial != null) characterPushForce *= 1f - rigidBodyPhysicsMaterial.Bounce;
 
                 // We already divided by the mass of the character to get acceleration from force, there's no need to do it again
@@ -1005,7 +1005,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                         {
                             pusher = new RigidBodyPusher
                             {
-                                Body = rigidBody,
+                                RigidBody = rigidBody,
                                 CharCenterToCollisionPosSmallestDist = collisionPosCharacterPosDiff.Length(),
                                 Character = Body,
                                 CollisionNormal = collisionNormal,

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -691,6 +691,16 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// </summary>
         class RigidBodyPusher
         {
+            /// <summary>
+            /// Distance into the colliding rigid body normal that the <see cref="GetCharacterVelocityChange"/> raycast starts at
+            /// </summary>
+            private static readonly float GET_CHAR_VELOCITY_CHANGE_RAY_START_INSET = 0.5f;
+
+            /// <summary>
+            /// Distance away from the colliding rigid body normal that the <see cref="GetCharacterVelocityChange"/> raycast ends at
+            /// </summary>
+            private static readonly float GET_CHAR_VELOCITY_CHANGE_RAY_END_OFFSET = 0.5f;
+
             public RigidBody3D RigidBody = null;
 
             public CharacterBody3D Character = null;
@@ -791,8 +801,8 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 Vector3 avgCollisionPoint = GetAvgCollisionPoint();
                 Vector3 negativeCharacterCollisionNormal = CharacterPushCollisionNormal;
                 PhysicsRayQueryParameters3D charCollisionNormalRayQueryParams = PhysicsRayQueryParameters3D.Create(
-                    avgCollisionPoint - CharacterPushCollisionNormal * 0.5f,
-                    avgCollisionPoint + CharacterPushCollisionNormal * 0.5f
+                    avgCollisionPoint - CharacterPushCollisionNormal * GET_CHAR_VELOCITY_CHANGE_RAY_START_INSET,
+                    avgCollisionPoint + CharacterPushCollisionNormal * GET_CHAR_VELOCITY_CHANGE_RAY_END_OFFSET
                 );
                 charCollisionNormalRayQueryParams.Exclude.Add(RigidBody.GetRid());
                 charCollisionNormalRayQueryParams.HitFromInside = false;

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -718,13 +718,8 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             public float RigidBodyCenterOfMassToCollisionPosSmallestDist = 0f;
 
             /// <summary>
-            /// Force applied by <see cref="RigidBody"/> on <see cref="Character"/>  
-            /// </summary>
-            //public Vector3 CharacterPushForce = Vector3.Zero;
-
-            /// <summary>
             /// Collision normal to use when figuring out how to apply force to the character.
-            /// This collision normal is the normal on the <i>rigid body</i>, not the character, in which <see cref="RigidBody"/>
+            /// This collision normal is the normal of the <i>rigid body</i>, not the character, in which <see cref="RigidBody"/>
             /// and <see cref="Character"/> touched.  
             /// </summary>
             public Vector3 CharacterPushCollisionNormal = Vector3.Zero;
@@ -751,8 +746,11 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             /// <summary>
             /// Pushes <see cref="RigidBody"/>. 
             /// </summary>
-            /// <param name="characterCurrentVelocity"></param>
-            /// <param name="characterTargetVelocity"></param>
+            /// <param name="characterCurrentVelocity">The current (or next) velocity of the character</param>
+            /// <param name="characterTargetVelocity">
+            /// The target velocity of the character (whose X and Z components are largely affected by
+            /// <see cref="RightValue"/> and <see cref="ForwardValue"/>)
+            /// </param>
             public void PushRigidBody(Vector3 characterCurrentVelocity, Vector3 characterTargetVelocity)
             {
                 if (characterCurrentVelocity == Vector3.Zero && characterTargetVelocity == Vector3.Zero) return;
@@ -779,8 +777,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             /// <summary>
             /// Returns the change in velocity corresponding to the force being applied to <see cref="Character"/> 
             /// </summary>
-            /// <param name="characterCurrentVelocity"></param>
-            /// <param name="characterTargetVelocity"></param>
+            /// <param name="characterCurrentVelocity">The current (or next) velocity of the character</param>
             public Vector3 GetCharacterVelocityChange(Vector3 characterCurrentVelocity)
             {
                 // Use a raycast to determine the collision normal of the character that was touched by the rigid body, using
@@ -801,7 +798,6 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                     CharacterBody3D cBody = vRaycastCollider.As<CharacterBody3D>();
                     if (cBody != null && Character == cBody)
                     {
-                        GD.Print("GetCharacterVelocityChange raycast hit the character.");
                         Variant vCollisionNormal;
                         if (raycastResult.TryGetValue("normal", out vCollisionNormal)) negativeCharacterCollisionNormal = -vCollisionNormal.As<Vector3>();
                     }

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -762,8 +762,10 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 // Calculating force multiplier this way is useful because the dot product of two perpendicular vectors is 0.
                 // If the dot product of charVelocity and negativeRigidBodyCollisionNormal are greater than 0, we can at least say that to some degree,
                 // charVelocity and negativeRigidBodyCollisionNormal aren't travelling in opposite or perpendicular directions.
-                Vector3 negativeRigidBodyCollisionNormal = -RigidBodyCollisionNormal;
-                float forceMultiplier = charVelocity.Dot(negativeRigidBodyCollisionNormal) - RigidBody.LinearVelocity.Dot(negativeRigidBodyCollisionNormal);
+                // 
+                // This calculation has also been optimized by taking into account the fact that adding two vectors that are going the opposite direction
+                // will cause the two vectors to "cancel each other out".
+                float forceMultiplier = charVelocity.Dot(-RigidBodyCollisionNormal) + RigidBody.LinearVelocity.Dot(RigidBodyCollisionNormal);
 
                 // If character doesn't have enough velocity to overcome rigid body velocity
                 // or if we know for sure that force application is physically impossible, stop.

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -703,7 +703,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             /// List of global-space coordinates that Body and Character are touching during the current physics frame
             /// </summary>
             public List<Vector3> CollisionPoints = [];
-            
+
             /// <summary>
             /// The closest distance between the center of the character and
             /// the point at which <see cref="Body"/> and <see cref="Character"/> collided.
@@ -711,24 +711,9 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             public float CharCenterToCollisionPosSmallestDist = 0f;
 
             /// <summary>
-            /// Where force should be applied to <see cref="Body"/> and <see cref="Character"/> in global coordinates.  
-            /// </summary>
-            //public Vector3 ForceApplicationPosition = Vector3.Zero;
-
-            /// <summary>
-            /// Force applied by <see cref="Character"/> on <see cref="Body"/>  
-            /// </summary>
-            //public Vector3 PushForce = Vector3.Zero;
-
-            /// <summary>
             /// Force applied by <see cref="Body"/> on <see cref="Character"/>  
             /// </summary>
             public Vector3 CharacterPushForce = Vector3.Zero;
-
-            /// <summary>
-            /// Number of consecutive physics frames that the character has *not* touched <see cref="Body"/> 
-            /// </summary>
-            public int ConsecutiveFramesUntouched = 0;
 
             private Vector3 GetAvgCollisionPoint()
             {
@@ -753,7 +738,6 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             {
                 if (characterCurrentVelocity == Vector3.Zero && characterTargetVelocity == Vector3.Zero) return;
 
-                //Vector3 avgCollisionPoint = GetAvgCollisionPoint();
                 Vector3 charVelocity = (characterCurrentVelocity.Length() > characterTargetVelocity.Length()) ? characterCurrentVelocity : characterTargetVelocity;
 
                 Vector3 pushDirection = charVelocity.Normalized();
@@ -773,17 +757,9 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
             /// </returns>
             public RigidBodyPusherCharacterPushData GetCharacterPushData()
             {
-                // Character push force and torque are calculated from the Wikipedia article on Line of Action
-                // https://en.wikipedia.org/wiki/Line_of_action
-                // 
-                // For the character, we assume that the center of mass is the actual/positional center of the character.
-                //Vector3 displacementFromCenterOfMass = ForceApplicationPosition - Character.GlobalPosition;
-
                 return new RigidBodyPusherCharacterPushData
                 {
                     VelocityChange = CharacterPushForce / Body.Mass,
-                    //DisplacementFromCenterOfMass = displacementFromCenterOfMass,
-                    //Torque = displacementFromCenterOfMass.Cross(CharacterPushForce)
                 };
             }
         }
@@ -995,7 +971,6 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                         RigidBodyPusher pusher;
 
                         Vector3 collisionNormal = collision.GetNormal();
-                        Vector3 forcePositionOffset = kinematicCollisionPos - rigidBody.GlobalPosition;
 
                         // CALCULATIONS FOR RIGIDBODY3D ATTEMPTS TO PUSH CHARACTER //
 
@@ -1013,22 +988,6 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
 
                         /////////////////////////////////////////////////////////////
 
-                        // CALCULATIONS FOR CHARACTER ATTEMPTS TO PUSH RIGID BODY 3D //
-
-                        //Vector3 rigidBodyPushDirection = -collisionNormal;
-
-                        // The amount in which rigidBody.Velocity has to change by to match pushDirection.
-                        // This number has a minimum of 0 to ensure that the character only pushes objects that it's travelling towards.
-                        //float diffToRigidBodyPushDirection = Math.Max(0f, finalVelocity.Dot(rigidBodyPushDirection) - rigidBody.LinearVelocity.Dot(rigidBodyPushDirection));
-
-                        // If rigidBody has more mass, it should be harder to push.
-                        //float reciprocatedMassRatio = Mass / rigidBody.Mass;
-
-                        // Put it together
-                        //Vector3 rigidBodyPushForce = rigidBodyPushDirection * diffToRigidBodyPushDirection * reciprocatedMassRatio * ForceMultiplier;
-
-                        ///////////////////////////////////////////////////////////////
-
                         Vector3 collisionPosCharacterPosDiff = kinematicCollisionPos - body.GlobalPosition;
 
                         // Remember, we only want to add force once per RigidBody3D per physics frame
@@ -1036,8 +995,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                         if (currentFrameRigidBodyPushers.TryGetValue(rigidBody, out pusher))
                         {
                             pusher.CollisionPoints.Add(kinematicCollisionPos);
-
-                            //Vector3 centerOfMass = rigidBody.CenterOfMass;
+                            
                             float collisionPosToCharacterPosDistance = collisionPosCharacterPosDiff.Length();
                             if (collisionPosToCharacterPosDistance < pusher.CharCenterToCollisionPosSmallestDist)
                             {

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -362,7 +362,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         public float Mass = 60f;
 
         /// <summary>
-        /// The "magnitude" in which the character pushes movable rigid bodies.
+        /// Multiplier for the force in which the character uses to push movable rigid bodies.
         /// <br/><br/>
         /// This is basically the same as the physical strength one uses to push an object.
         /// </summary>
@@ -371,7 +371,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
         /// <summary>
         /// Multiplier for the force applied by a <i>colliding</i> rigid body to the character being handled by this <see cref="BaseMover"/>. 
         /// </summary>
-        public float CharacterPushForceMultiplier = 5f;
+        public float CharacterPushForceMultiplier = 1f;
 
         private Vector2 lastXZVelocity = Vector2.Zero;
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -770,7 +770,7 @@ namespace UTheCat.Jumpvalley.Core.Players.Movement
                 // The amount in which finalVelocity (character velocity) has to change to match rigidBody.Velocity.
                 float charVelocityRigidBodyVelocityDiff = Body.LinearVelocity.Dot(CollisionNormal) - characterCurrentVelocity.Dot(-CollisionNormal);
 
-                // If applying the force would be physically impossible, don't apply the force.
+                // If we know for sure that applying the force would be physically impossible, don't apply the force.
                 if (charVelocityRigidBodyVelocityDiff <= 0) return Vector3.Zero;
 
                 // Objects heavier than the character should be able to push the character with greater force.


### PR DESCRIPTION
In this PR, the following scenarios have been improved and made more reliable:
- Character pushes a `RigidBody3D`
- A `RigidBody3D` pushes the character

When the character pushes a `RigidBody3D` along some path, the `RigidBody3D` now moves more predictably along the path.

Additionally, `RigidBody3D`s can now push the character more easily, and the way the physics for this plays out has been made more realistic. Because this resulted in `RigidBody3D`s being able to push the character much further distances, the default value of `BaseMover.CharacterPushForceMultiplier` has been reduced from `5f` to `1f` (which also made the push physics more realistic).

Here's a video demonstrating the result of these changes:


https://github.com/user-attachments/assets/15c7db64-578d-4f23-b892-2ff8fbd31a31



