### PR TITLE
Improve level menu animations

### DIFF
--- a/src/app/Gui/LevelMenu.cs
+++ b/src/app/Gui/LevelMenu.cs
@@ -11,7 +11,7 @@ namespace UTheCat.Jumpvalley.App.Gui
     /// </summary>
     public partial class LevelMenu : AnimatedNode, IDisposable
     {
-        private static readonly float MENU_HIDDEN_HEIGHT_REDUCTION = 40f;
+        private static readonly float MENU_HIDE_ANIM_HEIGHT_REDUCTION = 40f;
 
         /// <summary>
         /// Tween handling the transparency of the menu's items, including its background panel
@@ -124,7 +124,7 @@ namespace UTheCat.Jumpvalley.App.Gui
                 // its original height - backgroundSizeTween.GetCurrentValue() * 0.5.
                 // The width of BackgroundControl is adjusted accordingly with whatever
                 // widthHeightRatio is calculated to be.
-                backgroundSizeTween.InitialValue = MENU_HIDDEN_HEIGHT_REDUCTION;
+                backgroundSizeTween.InitialValue = MENU_HIDE_ANIM_HEIGHT_REDUCTION;
                 backgroundSizeTween.FinalValue = 0.0;
                 backgroundSizeTween.OnStep += (object o, double _frac) =>
                 {

--- a/src/app/Gui/LevelMenu.cs
+++ b/src/app/Gui/LevelMenu.cs
@@ -11,6 +11,8 @@ namespace UTheCat.Jumpvalley.App.Gui
     /// </summary>
     public partial class LevelMenu : AnimatedNode, IDisposable
     {
+        private static readonly float MENU_HIDDEN_HEIGHT_REDUCTION = 30f;
+
         /// <summary>
         /// Tween handling the transparency of the menu's items, including its background panel
         /// </summary>
@@ -122,7 +124,7 @@ namespace UTheCat.Jumpvalley.App.Gui
                 // its original height - backgroundSizeTween.GetCurrentValue() * 0.5.
                 // The width of BackgroundControl is adjusted accordingly with whatever
                 // widthHeightRatio is calculated to be.
-                backgroundSizeTween.InitialValue = 40.0;
+                backgroundSizeTween.InitialValue = MENU_HIDDEN_HEIGHT_REDUCTION;
                 backgroundSizeTween.FinalValue = 0.0;
                 backgroundSizeTween.OnStep += (object o, double _frac) =>
                 {

--- a/src/app/Gui/LevelMenu.cs
+++ b/src/app/Gui/LevelMenu.cs
@@ -13,10 +13,14 @@ namespace UTheCat.Jumpvalley.App.Gui
     {
         private static readonly float MENU_HIDE_ANIM_HEIGHT_REDUCTION = 40f;
 
+        // Both of these durations are in seconds
+        private static readonly double OPACITY_ANIM_DURATION = 0.2;
+        private static readonly double SIZE_ANIM_DURATION = 0.4;
+
         /// <summary>
-        /// Tween handling the transparency of the menu's items, including its background panel
+        /// Tween handling the opacity of the menu's items, including its background panel
         /// </summary>
-        private SceneTreeTween transparencyTween;
+        private SceneTreeTween opacityTween;
 
         /// <summary>
         /// Tween handling the appearance of the menu's background panel
@@ -61,7 +65,7 @@ namespace UTheCat.Jumpvalley.App.Gui
 
                 if (value)
                 {
-                    transparencyTween.Speed = 1;
+                    opacityTween.Speed = 1;
 
                     if (backgroundSizeTween != null)
                     {
@@ -70,7 +74,7 @@ namespace UTheCat.Jumpvalley.App.Gui
                 }
                 else
                 {
-                    transparencyTween.Speed = -1;
+                    opacityTween.Speed = -1;
 
                     if (backgroundSizeTween != null)
                     {
@@ -78,7 +82,7 @@ namespace UTheCat.Jumpvalley.App.Gui
                     }
                 }
 
-                transparencyTween.Resume();
+                opacityTween.Resume();
                 if (backgroundSizeTween != null)
                 {
                     backgroundSizeTween.Resume();
@@ -105,10 +109,10 @@ namespace UTheCat.Jumpvalley.App.Gui
             Vector2 nodeSize = actualNode.Size;
             widthHeightRatio = nodeSize.X / nodeSize.Y;
 
-            transparencyTween = new SceneTreeTween(0.2, Tween.TransitionType.Linear, Tween.EaseType.Out, tree);
-            transparencyTween.InitialValue = 0;
-            transparencyTween.FinalValue = 1;
-            transparencyTween.OnStep += (object o, double frac) =>
+            opacityTween = new SceneTreeTween(OPACITY_ANIM_DURATION, Tween.TransitionType.Linear, Tween.EaseType.Out, tree);
+            opacityTween.InitialValue = 0;
+            opacityTween.FinalValue = 1;
+            opacityTween.OnStep += (object o, double frac) =>
             {
                 actualNode.Visible = frac > 0.0;
                 Color modulate = actualNode.Modulate;
@@ -118,7 +122,7 @@ namespace UTheCat.Jumpvalley.App.Gui
 
             if (BackgroundControl != null)
             {
-                backgroundSizeTween = new SceneTreeTween(0.4, Tween.TransitionType.Quad, Tween.EaseType.Out, tree);
+                backgroundSizeTween = new SceneTreeTween(SIZE_ANIM_DURATION, Tween.TransitionType.Quad, Tween.EaseType.Out, tree);
 
                 // While tween is running, the height of BackgroundControl is set to
                 // its original height - backgroundSizeTween.GetCurrentValue() * 0.5.
@@ -149,7 +153,7 @@ namespace UTheCat.Jumpvalley.App.Gui
         {
             CloseButton.Pressed -= OnCloseButtonPressed;
 
-            transparencyTween.Dispose();
+            opacityTween.Dispose();
             backgroundSizeTween.Dispose();
         }
 

--- a/src/app/Gui/LevelMenu.cs
+++ b/src/app/Gui/LevelMenu.cs
@@ -11,7 +11,7 @@ namespace UTheCat.Jumpvalley.App.Gui
     /// </summary>
     public partial class LevelMenu : AnimatedNode, IDisposable
     {
-        private static readonly float MENU_HIDDEN_HEIGHT_REDUCTION = 30f;
+        private static readonly float MENU_HIDDEN_HEIGHT_REDUCTION = 40f;
 
         /// <summary>
         /// Tween handling the transparency of the menu's items, including its background panel

--- a/src/app/Gui/LevelMenu.cs
+++ b/src/app/Gui/LevelMenu.cs
@@ -103,7 +103,7 @@ namespace UTheCat.Jumpvalley.App.Gui
             Vector2 nodeSize = actualNode.Size;
             widthHeightRatio = nodeSize.X / nodeSize.Y;
 
-            transparencyTween = new SceneTreeTween(0.25, Tween.TransitionType.Linear, Tween.EaseType.Out, tree);
+            transparencyTween = new SceneTreeTween(0.2, Tween.TransitionType.Linear, Tween.EaseType.Out, tree);
             transparencyTween.InitialValue = 0;
             transparencyTween.FinalValue = 1;
             transparencyTween.OnStep += (object o, double frac) =>
@@ -116,7 +116,7 @@ namespace UTheCat.Jumpvalley.App.Gui
 
             if (BackgroundControl != null)
             {
-                backgroundSizeTween = new SceneTreeTween(0.5, Tween.TransitionType.Quad, Tween.EaseType.Out, tree);
+                backgroundSizeTween = new SceneTreeTween(0.4, Tween.TransitionType.Quad, Tween.EaseType.Out, tree);
 
                 // While tween is running, the height of BackgroundControl is set to
                 // its original height - backgroundSizeTween.GetCurrentValue() * 0.5.


### PR DESCRIPTION
In this PR, the show/hide animations of `LevelMenu` variants (e.g. `PrimaryLevelMenu`, `MusicPanel`) have been tweaked so that:
- Aspect ratio of the background panel is preserved when tweening its size
- Duration of the size and opacity animations have been reduced

Here's the result:

https://github.com/user-attachments/assets/a7e6eaad-2677-4a08-9ee1-3caa7c31c599

