### PR TITLE
Adapt primary level menu height to window height

### DIFF
--- a/gui/close_button.tscn
+++ b/gui/close_button.tscn
@@ -20,6 +20,7 @@ events = [SubResource("InputEventKey_n54he")]
 [node name="CloseButton" type="Button"]
 offset_right = 36.0
 offset_bottom = 36.0
+focus_mode = 0
 theme_override_styles/normal = SubResource("StyleBoxFlat_8psry")
 shortcut = SubResource("Shortcut_gq2pe")
 script = ExtResource("1_gq2pe")

--- a/gui/level_menu.tscn
+++ b/gui/level_menu.tscn
@@ -91,6 +91,7 @@ dragging_scroll_damper = SubResource("Resource_4y8uo")
 drag_with_mouse = false
 
 [node name="BoxContainer" type="BoxContainer" parent="Items/ScrollContainer"]
+custom_minimum_size = Vector2(315, 0)
 layout_mode = 2
 theme_override_constants/separation = 8
 vertical = true

--- a/gui/level_menu.tscn
+++ b/gui/level_menu.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=6 format=3 uid="uid://dgfjvgik6m4a5"]
+[gd_scene load_steps=10 format=3 uid="uid://dgfjvgik6m4a5"]
 
 [ext_resource type="FontFile" uid="uid://b6a3cplnxqrgp" path="res://addons/fonts/nunito/static/Nunito-Regular.ttf" id="1_r1p6m"]
+[ext_resource type="Script" uid="uid://bgqglerkcylxx" path="res://addons/SmoothScroll/SmoothScrollContainer.gd" id="2_kxwji"]
 [ext_resource type="PackedScene" uid="uid://olrc8iep31yb" path="res://gui/close_button.tscn" id="2_qiqfo"]
+[ext_resource type="Script" uid="uid://dlagxcnf11lr4" path="res://addons/SmoothScroll/scroll_damper/cubic_scroll_damper.gd" id="3_3gqnh"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_2tlkk"]
 bg_color = Color(0.105882, 0.105882, 0.105882, 1)
@@ -17,6 +19,18 @@ font_size = 48
 [sub_resource type="LabelSettings" id="LabelSettings_kiqen"]
 font = ExtResource("1_r1p6m")
 font_size = 24
+
+[sub_resource type="Resource" id="Resource_my8hv"]
+script = ExtResource("3_3gqnh")
+friction = 4.0
+rebound_strength = 7.0
+metadata/_custom_type_script = "uid://dlagxcnf11lr4"
+
+[sub_resource type="Resource" id="Resource_4y8uo"]
+script = ExtResource("3_3gqnh")
+friction = 4.0
+rebound_strength = 7.0
+metadata/_custom_type_script = "uid://dlagxcnf11lr4"
 
 [node name="LevelMenu" type="Control"]
 layout_mode = 3
@@ -71,6 +85,22 @@ anchor_top = 0.05
 anchor_right = 0.95
 anchor_bottom = 0.95
 offset_top = 100.0
+
+[node name="ScrollContainer" type="ScrollContainer" parent="Items"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("2_kxwji")
+wheel_scroll_damper = SubResource("Resource_my8hv")
+dragging_scroll_damper = SubResource("Resource_4y8uo")
+drag_with_mouse = false
+
+[node name="BoxContainer" type="BoxContainer" parent="Items/ScrollContainer"]
+layout_mode = 2
+vertical = true
 
 [node name="CloseButton" parent="." instance=ExtResource("2_qiqfo")]
 layout_mode = 1

--- a/gui/level_menu.tscn
+++ b/gui/level_menu.tscn
@@ -34,17 +34,9 @@ metadata/_custom_type_script = "uid://dlagxcnf11lr4"
 
 [node name="LevelMenu" type="Control"]
 layout_mode = 3
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -175.0
-offset_top = -200.0
-offset_right = 175.0
-offset_bottom = 200.0
-grow_horizontal = 2
-grow_vertical = 2
+anchors_preset = 0
+offset_right = 350.0
+offset_bottom = 400.0
 
 [node name="Background" type="Panel" parent="."]
 layout_mode = 1

--- a/gui/level_menu.tscn
+++ b/gui/level_menu.tscn
@@ -100,6 +100,7 @@ drag_with_mouse = false
 
 [node name="BoxContainer" type="BoxContainer" parent="Items/ScrollContainer"]
 layout_mode = 2
+theme_override_constants/separation = 8
 vertical = true
 
 [node name="CloseButton" parent="." instance=ExtResource("2_qiqfo")]

--- a/gui/level_menu_button.tscn
+++ b/gui/level_menu_button.tscn
@@ -1,10 +1,49 @@
-[gd_scene load_steps=5 format=3 uid="uid://du6etgmkelt2n"]
+[gd_scene load_steps=8 format=3 uid="uid://du6etgmkelt2n"]
 
 [ext_resource type="FontFile" uid="uid://b6a3cplnxqrgp" path="res://addons/fonts/nunito/static/Nunito-Regular.ttf" id="1_3oj0a"]
 [ext_resource type="Texture2D" uid="uid://ciuwq1360hfy5" path="res://addons/icons/more_horiz_white_24dp.svg" id="2_ubqv8"]
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fbqry"]
+content_margin_left = 3.0
+content_margin_top = 3.0
+content_margin_right = 3.0
+content_margin_bottom = 3.0
+draw_center = false
+border_width_left = 6
+border_width_top = 6
+border_width_right = 6
+border_width_bottom = 6
+border_color = Color(1, 1, 1, 1)
+corner_radius_top_left = 10
+corner_radius_top_right = 10
+corner_radius_bottom_right = 10
+corner_radius_bottom_left = 10
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_c1hga"]
+bg_color = Color(0.4, 0.4, 0.4, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+corner_radius_top_left = 10
+corner_radius_top_right = 10
+corner_radius_bottom_right = 10
+corner_radius_bottom_left = 10
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8xhrg"]
+bg_color = Color(0.3, 0.3, 0.3, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.6, 0.6, 0.6, 1)
+corner_radius_top_left = 10
+corner_radius_top_right = 10
+corner_radius_bottom_right = 10
+corner_radius_bottom_left = 10
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jjwbe"]
-bg_color = Color(0.501961, 0.501961, 0.501961, 1)
+bg_color = Color(0.5, 0.5, 0.5, 1)
 border_width_left = 4
 border_width_top = 4
 border_width_right = 4
@@ -24,8 +63,12 @@ custom_minimum_size = Vector2(0, 44)
 anchors_preset = 10
 anchor_right = 1.0
 offset_bottom = 44.0
+focus_mode = 0
 theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_font_sizes/font_size = 24
+theme_override_styles/focus = SubResource("StyleBoxFlat_fbqry")
+theme_override_styles/hover = SubResource("StyleBoxFlat_c1hga")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_8xhrg")
 theme_override_styles/normal = SubResource("StyleBoxFlat_jjwbe")
 
 [node name="Label" type="Label" parent="."]

--- a/gui/level_menu_button.tscn
+++ b/gui/level_menu_button.tscn
@@ -20,6 +20,7 @@ font = ExtResource("1_3oj0a")
 font_size = 24
 
 [node name="LevelMenuButton" type="Button"]
+custom_minimum_size = Vector2(0, 44)
 anchors_preset = 10
 anchor_right = 1.0
 offset_bottom = 44.0

--- a/main.tscn
+++ b/main.tscn
@@ -130,8 +130,18 @@ offset_bottom = -52.0
 grow_vertical = 0
 
 [node name="PrimaryLevelMenu" parent="PrimaryGui" instance=ExtResource("6_faadj")]
-visible = false
 layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -175.0
+offset_top = -200.0
+offset_right = 175.0
+offset_bottom = 200.0
+grow_horizontal = 2
+grow_vertical = 2
 metadata/keybind_open_menu = SubResource("InputEventKey_ycdy4")
 
 [node name="IntroPanel" parent="PrimaryGui" instance=ExtResource("9_e2o57")]

--- a/src/app/Gui/LevelMenu.cs
+++ b/src/app/Gui/LevelMenu.cs
@@ -48,6 +48,20 @@ namespace UTheCat.Jumpvalley.App.Gui
         public Control ItemsControl { get; private set; }
 
         /// <summary>
+        /// The scroll container (which is a child of <see cref="ItemsControl"/>)
+        /// that spans the entire size of <see cref="ItemsControl"/>.
+        /// </summary>
+        public ScrollContainer ItemsScrollContainer { get; private set; }
+
+        /// <summary>
+        /// Node which is a child of <see cref="ItemsScrollContainer"/>.
+        /// <br/><br/>
+        /// If the ability to scroll through the level menu's items is desired,
+        /// the level menu's items should be placed in this container.
+        /// </summary>
+        public BoxContainer ScrollableItemsBoxContainer { get; private set; }
+
+        /// <summary>
         /// The button that closes the menu when pressed
         /// </summary>
         public Button CloseButton { get; private set; }
@@ -103,8 +117,11 @@ namespace UTheCat.Jumpvalley.App.Gui
             BackgroundControl = actualNode.GetNodeOrNull<Control>("Background");
             TitleLabel = actualNode.GetNodeOrNull<Label>("Title");
             SubtitleLabel = actualNode.GetNodeOrNull<Label>("Subtitle");
-            ItemsControl = actualNode.GetNodeOrNull<Control>("Items");
             CloseButton = actualNode.GetNodeOrNull<Button>("CloseButton");
+
+            ItemsControl = actualNode.GetNodeOrNull<Control>("Items");
+            ItemsScrollContainer = ItemsControl?.GetNodeOrNull<ScrollContainer>("ScrollContainer");
+            ScrollableItemsBoxContainer = ItemsScrollContainer?.GetNodeOrNull<BoxContainer>("BoxContainer");
 
             Vector2 nodeSize = actualNode.Size;
             widthHeightRatio = nodeSize.X / nodeSize.Y;

--- a/src/app/Gui/LevelMenu.cs
+++ b/src/app/Gui/LevelMenu.cs
@@ -142,6 +142,7 @@ namespace UTheCat.Jumpvalley.App.Gui
 
             Vector2 nodeSize = actualNode.Size;
 
+            originalHeight = nodeSize.Y;
             originalOffsetTop = actualNode.OffsetTop;
             originalOffsetBottom = actualNode.OffsetBottom;
 

--- a/src/app/Gui/LevelMenu.cs
+++ b/src/app/Gui/LevelMenu.cs
@@ -28,16 +28,6 @@ namespace UTheCat.Jumpvalley.App.Gui
         private SceneTreeTween backgroundSizeTween;
 
         /// <summary>
-        /// Current size of the level menu
-        /// </summary>
-        private Vector2 currentSize = Vector2.Zero;
-
-        /// <summary>
-        /// Size of the actual level menu when this level menu handler was instantiated
-        /// </summary>
-        private Vector2 originalSize = Vector2.Zero;
-
-        /// <summary>
         /// Height of the actual level menu when this level menu handler was instantiated
         /// </summary>
         private float originalHeight = 0f;
@@ -128,11 +118,8 @@ namespace UTheCat.Jumpvalley.App.Gui
 
         private float widthHeightRatio;
         private Control menuRootNode;
-        private float originalOffsetLeft;
-        private float originalOffsetRight;
         private float originalOffsetTop;
         private float originalOffsetBottom;
-        private float originalYPos;
 
         /// <summary>
         /// Constructs a new instance of the level menu handler.
@@ -154,11 +141,7 @@ namespace UTheCat.Jumpvalley.App.Gui
             menuRootNode = actualNode;
 
             Vector2 nodeSize = actualNode.Size;
-            originalSize = nodeSize;
-            originalHeight = nodeSize.Y;
 
-            originalOffsetLeft = actualNode.OffsetLeft;
-            originalOffsetRight = actualNode.OffsetRight;
             originalOffsetTop = actualNode.OffsetTop;
             originalOffsetBottom = actualNode.OffsetBottom;
 
@@ -226,11 +209,6 @@ namespace UTheCat.Jumpvalley.App.Gui
             return windowHeight < originalHeight ? originalHeight - windowHeight : 0f;
         }
 
-        private float GetHeightReductionDueToWindowHeight()
-        {
-            return GetHeightReductionDueToWindowHeight(DisplayServer.WindowGetSize().Y);
-        }
-
         public override void _Process(double delta)
         {
             Vector2I windowSize = DisplayServer.WindowGetSize();
@@ -240,10 +218,7 @@ namespace UTheCat.Jumpvalley.App.Gui
             {
                 lastWindowHeight = height;
                 float heightReduction = GetHeightReductionDueToWindowHeight(height);
-                //Vector2 rootNodeSize = menuRootNode.Size;
-                //menuRootNode.Size = new Vector2(rootNodeSize.X, originalHeight - heightReduction);
                 float halfHeightReduction = (heightReduction > 0) ? heightReduction * 0.5f : 0f;
-                //float halfWidthReduction = halfHeightReduction * widthHeightRatio;
 
                 if (AdaptHeightToWindowSize)
                 {

--- a/src/app/Gui/PrimaryLevelMenu.cs
+++ b/src/app/Gui/PrimaryLevelMenu.cs
@@ -72,7 +72,7 @@ namespace UTheCat.Jumpvalley.App.Gui
 			{
 				// Quit the app in the method specified in the Godot documentation:
 				// https://docs.godotengine.org/en/stable/tutorials/inputs/handling_quit_requests.html
-				tree.Root.PropagateNotification((int)Node.NotificationWMCloseRequest);
+				tree.Root.PropagateNotification((int)NotificationWMCloseRequest);
 				tree.Quit();
 			};
 			exitAppButtonHandler.BackgroundColor = Color.Color8(255, 100, 89, 255);
@@ -86,15 +86,17 @@ namespace UTheCat.Jumpvalley.App.Gui
 				settingsButton.ActualButton,
 				exitAppButton
 			};
-			float buttonYSize = exitAppButton.Size.Y;
+			foreach (Button b in buttonList) ScrollableItemsBoxContainer.AddChild(b);
 
-			for (int i = 0; i < buttonList.Length; i++)
-			{
-				Button b = buttonList[i];
-				b.OffsetTop = BUTTON_Y_POS_DIFF * i;
-				b.OffsetBottom = b.OffsetTop + buttonYSize;
-				ItemsControl.AddChild(b);
-			}
+			// float buttonYSize = exitAppButton.Size.Y;
+
+			// for (int i = 0; i < buttonList.Length; i++)
+			// {
+			// 	Button b = buttonList[i];
+			// 	b.OffsetTop = BUTTON_Y_POS_DIFF * i;
+			// 	b.OffsetBottom = b.OffsetTop + buttonYSize;
+			// 	ItemsControl.AddChild(b);
+			// }
 
 			if (actualNode.HasMeta(KEYBIND_OPEN_MENU_META_NAME))
 			{

--- a/src/app/Gui/PrimaryLevelMenu.cs
+++ b/src/app/Gui/PrimaryLevelMenu.cs
@@ -10,8 +10,18 @@ namespace UTheCat.Jumpvalley.App.Gui
 	/// </summary>
 	public partial class PrimaryLevelMenu : LevelMenu, IDisposable
 	{
-		private readonly float BUTTON_Y_POS_DIFF = 52f;
-		private readonly string KEYBIND_OPEN_MENU_META_NAME = "keybind_open_menu";
+		private static readonly string KEYBIND_OPEN_MENU_META_NAME = "keybind_open_menu";
+		private static readonly Key[] MENU_OPTION_KEYBINDS = [
+			Key.Key1,
+			Key.Key2,
+			Key.Key3,
+			Key.Key4,
+			Key.Key5,
+			Key.Key6,
+			Key.Key7,
+			Key.Key8,
+			Key.Key9
+		];
 
 		private List<IDisposable> disposables;
 
@@ -86,7 +96,21 @@ namespace UTheCat.Jumpvalley.App.Gui
 				settingsButton.ActualButton,
 				exitAppButton
 			};
-			foreach (Button b in buttonList) ScrollableItemsBoxContainer.AddChild(b);
+			for (int i = 0; i < buttonList.Length; i++)
+			{
+				Button b = buttonList[i];
+				if (i < MENU_OPTION_KEYBINDS.Length)
+				{
+					InputEventKey key = new InputEventKey();
+					key.Keycode = MENU_OPTION_KEYBINDS[i];
+
+					Shortcut shortcut = new Shortcut();
+					shortcut.Events.Add(key);
+					b.Shortcut = shortcut;
+				}
+
+				ScrollableItemsBoxContainer.AddChild(b);
+			}
 
 			// float buttonYSize = exitAppButton.Size.Y;
 
@@ -122,8 +146,8 @@ namespace UTheCat.Jumpvalley.App.Gui
 			base.Dispose();
 		}
 
-        public override void _Input(InputEvent @event)
-        {
+		public override void _Input(InputEvent @event)
+		{
 			BgPanelAnimatedNodeGroup bgpNodeGroup = BgPanelNodeGroup;
 			if ((bgpNodeGroup == null || !bgpNodeGroup.ShouldBeVisible)
 				&& @event is InputEventKey keyInput
@@ -135,7 +159,7 @@ namespace UTheCat.Jumpvalley.App.Gui
 				return;
 			}
 
-            base._Input(@event);
-        }
+			base._Input(@event);
+		}
 	}
 }

--- a/src/app/Gui/PrimaryLevelMenu.cs
+++ b/src/app/Gui/PrimaryLevelMenu.cs
@@ -11,6 +11,13 @@ namespace UTheCat.Jumpvalley.App.Gui
 	public partial class PrimaryLevelMenu : LevelMenu, IDisposable
 	{
 		private static readonly string KEYBIND_OPEN_MENU_META_NAME = "keybind_open_menu";
+
+		/// <summary>
+		/// Keyboard shortcuts for the menu's options (other than the close button).
+		/// <br/><br/>
+		/// Higher index means the keyboard shortcut is used for a menu option that's
+		/// lower in the option list displayed to the user.
+		/// </summary>
 		private static readonly Key[] MENU_OPTION_KEYBINDS = [
 			Key.Key1,
 			Key.Key2,

--- a/src/app/Gui/PrimaryLevelMenu.cs
+++ b/src/app/Gui/PrimaryLevelMenu.cs
@@ -47,6 +47,9 @@ namespace UTheCat.Jumpvalley.App.Gui
 		{
 			disposables = new List<IDisposable>();
 
+			ScrollContainer scrollContainer = ItemsScrollContainer;
+			if (scrollContainer != null) scrollContainer.HorizontalScrollMode = ScrollContainer.ScrollMode.Disabled;
+
 			if (TitleLabel != null)
 			{
 				TitleLabel.Text = actualNode.Tr("MENU_TITLE");

--- a/src/app/JumpvalleyPlayer.cs
+++ b/src/app/JumpvalleyPlayer.cs
@@ -193,6 +193,7 @@ namespace UTheCat.Jumpvalley.App
             PrimaryLevelMenu primaryLevelMenu = new PrimaryLevelMenu(primaryLevelMenuNode, Tree);
             animatedNodes.Add("primary_level_menu", primaryLevelMenu);
             primaryLevelMenu.BgPanelNodeGroup = animatedNodes;
+            primaryLevelMenu.AdaptHeightToWindowSize = true;
 
             Disposables.Add(primaryLevelMenu);
             Disposables.Add(primaryLevelMenuNode);


### PR DESCRIPTION
This PR makes it so that the height of the primary level menu will no longer exceed the height of the app's client area (which is basically the height of the window without window decorations).

Other changes have also been made for UX reasons, including:

- Changed focus behavior of some buttons
- Added keyboard shortcuts for primary level menu items. The `1` and `2` keys (not including the ones on the numpad) can now be used to show the settings menu and exit the app, respectively.


https://github.com/user-attachments/assets/69f253ba-a5a4-44ce-a254-bf9466afbb80

