### PR TITLE
Fix memory leaks (2025-09-13)

### DIFF
--- a/src/app/Gui/FramerateCounter.cs
+++ b/src/app/Gui/FramerateCounter.cs
@@ -93,6 +93,7 @@ namespace UTheCat.Jumpvalley.App.Gui
         public new void Dispose()
         {
             opacityTween.Dispose();
+            base.Dispose();
         }
     }
 }

--- a/src/app/Gui/LevelMenu.cs
+++ b/src/app/Gui/LevelMenu.cs
@@ -194,6 +194,7 @@ namespace UTheCat.Jumpvalley.App.Gui
 
             opacityTween.Dispose();
             backgroundSizeTween.Dispose();
+            base.Dispose();
         }
 
         private void OnCloseButtonPressed()

--- a/src/app/Gui/SettingsMenu.cs
+++ b/src/app/Gui/SettingsMenu.cs
@@ -176,6 +176,8 @@ namespace UTheCat.Jumpvalley.App.Gui
             foreach (SettingUiHandler handler in settingUiHandlers) handler.Dispose();
 
             settingUiHandlers.Clear();
+
+            base.Dispose();
         }
     }
 }

--- a/src/app/JumpvalleyPlayer.cs
+++ b/src/app/JumpvalleyPlayer.cs
@@ -182,6 +182,9 @@ namespace UTheCat.Jumpvalley.App
                 CanOnlyShowOneNode = true
             };
 
+            Disposables.Add(animatedNodes);
+            Disposables.Add(bgPanel);
+
             // Bottom bar
             BottomBar bottomBar = new BottomBar(PrimaryGui.GetNode("BottomBar"), musicPlayer)
             {
@@ -206,6 +209,7 @@ namespace UTheCat.Jumpvalley.App
             MusicPanel musicPanel = new MusicPanel(musicPlayer, musicPanelNode, Tree);
             musicPanel.BindMusicVolumeSliderWithSetting(settings.Group.GetNode<MusicVolumeControl>("audio/music_volume"));
             animatedNodes.Add("music_panel", musicPanel);
+            Disposables.Add(musicPanel);
 
             //bottomBar.PrimaryMusicPanel = musicPanel;
 

--- a/src/core/Animation/AnimatedNode.cs
+++ b/src/core/Animation/AnimatedNode.cs
@@ -7,7 +7,7 @@ namespace UTheCat.Jumpvalley.Core.Animation
     /// This class provides some components to bind to a Godot node,
     /// mainly to assist with writing animation code for the node.
     /// </summary>
-    public partial class AnimatedNode : Node
+    public partial class AnimatedNode : Node, IDisposable
     {
         /// <summary>
         /// The node to be animated
@@ -51,5 +51,13 @@ namespace UTheCat.Jumpvalley.Core.Animation
         {
             VisibilityChanged?.Invoke(this, isVisible);
         }
+
+        /// <summary>
+        /// Disposes of this <see cref="AnimatedNode"/>.
+        /// <br/><br/>
+        /// To assist with garbage collection, this method will automatically call
+        /// the <see cref="AnimatedNode"/>'s QueueFree method.
+        /// </summary>
+        public new void Dispose() => QueueFree();
     }
 }


### PR DESCRIPTION
This PR fixes memory leaks caused by changing `AnimatedNode` to inherit from Godot's `Node` class.